### PR TITLE
Fixed: mapchange crash, and latest amtl/amxmodx support.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -100,7 +100,7 @@ elif cxx.like('msvc'):
   cxx.linkflags += [
     '/MACHINE:X86',
     '/SUBSYSTEM:WINDOWS',
-
+    '/EXPORT:GiveFnptrsToDll=_GiveFnptrsToDll@8,@1',
     'kernel32.lib'
   ]
 

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -72,8 +72,7 @@ if cxx.like('gcc'):
     '-Wno-unused-value',
     '-fno-strict-aliasing',
     '-fPIC',
-    '-m32',
-    '-fpermissive'
+    '-m32'
   ]
 
   cxx.cxxflags += [
@@ -158,3 +157,4 @@ binary.sources += [
 #
 
 builder.Add(binary)
+

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -72,11 +72,12 @@ if cxx.like('gcc'):
     '-Wno-unused-value',
     '-fno-strict-aliasing',
     '-fPIC',
-    '-m32'
+    '-m32',
+    '-fpermissive'
   ]
 
   cxx.cxxflags += [
-    '-std=c++11',
+    '-std=gnu++14',
     '-fno-exceptions',
     '-fno-rtti'
   ]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Amxx-Module-CustomEntityData
+API for saving custom entity data easily through AMXX plugins
+
+# Linux
+Since libgcc_s.so.1 and libstdc++.so.6 bundled with HLDS for Linux are too old, install the latest GCC and place symbolic links to the respective libraries.
+
+1. install gcc over than 11.3.1
+2. command execute.
+
++ cd /[your hlds directory]/
+
++ mv libgcc_s.so.1 libgcc_s.so.1.bk
++ mv libstdc++.so.6 libstdc++.so.6.bk
+
++ ln -s /usr/lib/libgcc_s.so.1 libgcc_s.so.1
++ ln -s /usr/lib/libstdc++.so.6 libstdc++.so.6

--- a/public/IGameConfigs.h
+++ b/public/IGameConfigs.h
@@ -1,0 +1,182 @@
+/**
+ * vim: set ts=4 :
+ * =============================================================================
+ * SourceMod
+ * Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
+ * =============================================================================
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 3.0, as published by the
+ * Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * As a special exception, AlliedModders LLC gives you permission to link the
+ * code of this program (as well as its derivative works) to "Half-Life 2," the
+ * "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+ * by the Valve Corporation.  You must obey the GNU General Public License in
+ * all respects for all other code used.  Additionally, AlliedModders LLC grants
+ * this exception to all derivative works.  AlliedModders LLC defines further
+ * exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+ * or <http://www.sourcemod.net/license.php>.
+ *
+ * Version: $Id$
+ */
+
+#ifndef _INCLUDE_IGAMECONFIG_H_
+#define _INCLUDE_IGAMECONFIG_H_
+
+#include <ITextParsers.h>
+
+enum class FieldType
+{
+	FIELD_NONE,
+	FIELD_FLOAT,        // Floating point value
+	FIELD_STRINGINT,    // String ID (return from ALLOC_STRING)
+	FIELD_STRINGPTR,    // String, pointer-to-char
+	FIELD_STRING,       // String, fixed size
+	FIELD_CLASSPTR,     // Classes pointer derived of CBaseEntity
+	FIELD_CLASS,        // Arbitrary classes, direct
+	FIELD_STRUCTURE,    // Arbitrary structures, direct
+	FIELD_EHANDLE,      // Entity handle
+	FIELD_ENTVARS,      // entvars_t*
+	FIELD_EDICT,        // edict_t*
+	FIELD_VECTOR,       // Vector
+	FIELD_POINTER,      // Arbitrary data pointer
+	FIELD_INTEGER,      // Integer or enum
+	FIELD_FUNCTION,     // Class function pointer (Think, Use, etc)
+	FIELD_BOOLEAN,      // Boolean
+	FIELD_SHORT,        // 2 bytes integer
+	FIELD_CHARACTER,    // 1 byte
+};
+
+struct TypeDescription
+{
+	TypeDescription()
+	{
+		reset();
+	}
+
+	void reset()
+	{
+		fieldType     = FieldType::FIELD_NONE;
+		fieldOffset   = 0;
+		fieldSize     = 0;
+		fieldUnsigned = false;
+	}
+
+	FieldType  fieldType;
+	int        fieldOffset;
+	int        fieldSize;
+	bool       fieldUnsigned;
+};
+
+/**
+ * @brief Describes a game private data config file
+ */
+class IGameConfig
+{
+public:
+	/**
+	 * @brief Returns an offset value.
+	 *
+	 * @param key			Key to retrieve from the offset section.
+	 * @param value			Pointer to store the TypeDescription reference in.
+	 * @return				True if found, false otherwise.
+	 */
+	virtual bool GetOffset(const char *key, TypeDescription *value) = 0;
+
+	/**
+	 * @brief Returns an offset value from given class.
+	 *
+	 * @param classname		class name to match from the offset section.
+	 * @param key			Key to retrieve from the offset section.
+	 * @param value			Pointer to store the TypeDescription reference in.
+	 * @return				True if found, false otherwise.
+	 */
+	virtual bool GetOffsetByClass(const char *classname, const char *key, TypeDescription *value) = 0;
+ 
+	/**
+	 * @brief Returns the value of a key from the "Keys" section.
+	 *
+	 * @param key			Key to retrieve from the Keys section.
+	 * @return				String containing the value, or NULL if not found.
+	 */
+	virtual const char *GetKeyValue(const char *key) = 0;
+
+	/**
+	 * @brief Retrieves a cached memory signature.
+	 *
+	 * @param key			Name of the signature.
+	 * @param addr			Pointer to store the memory address in.
+	 *						(NULL is copied if signature is not found in binary).
+	 * @return				True if the section exists and key for current
+	 *						platform was found, false otherwise.
+	 */
+	virtual bool GetMemSig(const char *key, void **addr) = 0;
+
+	/**
+	 * @brief Retrieves the value of an address from the "Address" section.
+	 *
+	 * @param key			Key to retrieve from the Address section.
+	 * @param addr          Pointer to store the memory address.
+	 * @return				True on success, false on failure.
+	 */
+	virtual bool GetAddress(const char *key, void **addr) = 0;
+};
+
+/**
+ * @brief Manages game config files
+ */
+class IGameConfigManager
+{
+public:
+	/**
+	 * @brief Loads or finds an already loaded game config file.  
+	 *
+	 * @param file		File to load.  The path must be relative to the 
+	 *					'gamedata' folder and the extension should be 
+	 *					omitted.
+	 * @param pConfig	Pointer to store the game config pointer.  Pointer 
+	 *					will be valid even on failure.
+	 * @param error		Optional error message buffer.
+	 * @param maxlength	Maximum length of the error buffer.
+	 * @return			True on success, false if the file failed.
+	 */
+	virtual bool LoadGameConfigFile(const char *file, IGameConfig **pConfig, char *error, size_t maxlength) = 0;
+
+	/**
+	 * @brief Closes an IGameConfig pointer.  Since a file can be loaded 
+	 * more than once, the file will not actually be removed from memory 
+	 * until it is closed once for each call to LoadGameConfigfile().
+	 *
+	 * @param cfg		Pointer to the IGameConfig to close.
+	 */
+	virtual void CloseGameConfigFile(IGameConfig *cfg) = 0;
+
+	/**
+	 * @brief Adds a custom gamedata section hook.
+	 *
+	 * @param sectionname	Section name to hook.
+	 * @param listener		Listener callback.
+	 * @noreturn
+	 */
+	virtual void AddUserConfigHook(const char *sectionname, ITextListener_SMC *listener) = 0;
+
+	/**
+	 * @brief Removes a custom gamedata section hook.
+	 *
+	 * @param sectionname	Section name to unhook.
+	 * @param listener		Listener callback.
+	 * @noreturn
+	 */
+	virtual void RemoveUserConfigHook(const char *sectionname, ITextListener_SMC *listener) = 0;
+};
+
+#endif //_INCLUDE_IGAMECONFIG_H_

--- a/public/ITextParsers.h
+++ b/public/ITextParsers.h
@@ -1,0 +1,462 @@
+/**
+ * vim: set ts=4 :
+ * =============================================================================
+ * SourceMod
+ * Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
+ * =============================================================================
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 3.0, as published by the
+ * Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * As a special exception, AlliedModders LLC gives you permission to link the
+ * code of this program (as well as its derivative works) to "Half-Life 2," the
+ * "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+ * by the Valve Corporation.  You must obey the GNU General Public License in
+ * all respects for all other code used.  Additionally, AlliedModders LLC grants
+ * this exception to all derivative works.  AlliedModders LLC defines further
+ * exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+ * or <http://www.sourcemod.net/license.php>.
+ *
+ * Version: $Id$
+ */
+
+#ifndef _INCLUDE_SOURCEMOD_TEXTPARSERS_INTERFACE_H_
+#define _INCLUDE_SOURCEMOD_TEXTPARSERS_INTERFACE_H_
+
+#include <string.h> // size_t
+
+/**
+ * @file ITextParsers.h
+ * @brief Defines various text/file parsing functions, as well as UTF-8 support code.
+ */
+//namespace SourceMod
+//{
+
+	#define SMINTERFACE_TEXTPARSERS_NAME		"ITextParsers"
+	#define SMINTERFACE_TEXTPARSERS_VERSION		4
+
+	/**
+	 * The INI file format is defined as:
+	 * WHITESPACE: 0x20, \n, \t, \r
+	 * IDENTIFIER: A-Z a-z 0-9 _ - , + . $ ? / 
+	 * STRING: Any set of symbols
+	 * 
+	 * Basic syntax is comprised of SECTIONs.
+	 * A SECTION is defined as:
+	 * [SECTIONNAME]
+	 * OPTION
+	 * OPTION
+	 * OPTION...
+	 *
+	 * SECTIONNAME is an IDENTIFIER.
+	 * OPTION can be repeated any number of times, once per line.
+	 * OPTION is defined as one of:
+	 *  KEY = "VALUE"
+	 *  KEY = VALUE
+	 *  KEY
+	 * Where KEY is an IDENTIFIER and VALUE is a STRING.
+	 * 
+	 * WHITESPACE should always be omitted.
+	 * COMMENTS should be stripped, and are defined as text occurring in:
+	 * ;<TEXT>
+	 * 
+	 * Example file below.  Note that
+	 * The second line is technically invalid.  The event handler
+	 * must decide whether this should be allowed.
+	 * --FILE BELOW--
+	 * [gaben]
+	 * hi = clams
+	 * bye = "NO CLAMS"
+	 *
+	 * [valve]
+	 * cannot
+	 * maintain
+	 * products
+	 */
+
+	/**
+	 * @brief Contains parse events for INI files.
+	 */
+	class ITextListener_INI
+	{
+	public:
+		/** 
+		 * @brief Returns version number.
+		 */
+		virtual unsigned int GetTextParserVersion1()
+		{
+			return SMINTERFACE_TEXTPARSERS_VERSION;
+		}
+	public:
+		/**
+		* @brief Called when starting parsing.
+		*/
+		virtual void ReadINI_ParseStart()
+		{
+		};
+
+		/**
+		* @brief Called when ending parsing.
+		*
+		* @param halted			True if abnormally halted, false otherwise.
+		*/
+		virtual void ReadINI_ParseEnd(bool halted)
+		{
+		}
+
+		/**
+		 * @brief Called when a new section is encountered in an INI file.
+		 * 
+		 * @param section		Name of section in between the [ and ] characters.
+		 * @param invalid_tokens True if invalid tokens were detected in the name.
+		 * @param close_bracket	True if a closing bracket was detected, false otherwise.
+		 * @param extra_tokens	True if extra tokens were detected on the line.
+		 * @param curtok		Contains current token in the line where the section name starts.
+		 *						You can add to this offset when failing to point to a token.
+		 * @return				True to keep parsing, false otherwise.
+		 */
+		virtual bool ReadINI_NewSection(const char *section, bool invalid_tokens, bool close_bracket, bool extra_tokens, unsigned int *curtok)
+		{
+			return true;
+		}
+
+		/**
+		 * @brief Called when encountering a key/value pair in an INI file.
+		 * 
+		 * @param key			Name of key.
+		 * @param value			String containing value (with quotes stripped, if any).
+		 * @param invalid_tokens Whether or not the key contained invalid tokens.
+		 * @param equal_token	There was an '=' sign present (in case the value is missing).
+		 * @param quotes		Whether value was enclosed in quotes.
+		 * @param curtok		Contains the token index of the start of the value string.  
+		 *						This can be changed when returning false.
+		 * @return				True to keep parsing, false otherwise.
+		 */
+		virtual bool ReadINI_KeyValue(const char *key, const char *value, bool invalid_tokens, bool equal_token, bool quotes, unsigned int *curtok)
+		{
+			return true;
+		}
+
+		/**
+		 * @brief Called after a line has been preprocessed, if it has text.
+		 *
+		 * @param line			Contents of line.
+		 * @param curtok		Pointer to optionally store failed position in string.
+		 *
+		 * @return				True to keep parsing, false otherwise.
+		 */
+		virtual bool ReadINI_RawLine(const char *line, unsigned int *curtok)
+		{
+			return true;
+		}
+	};
+
+	/**
+	 * :TODO: write this in CFG (context free grammar) format so it makes sense
+	 * 
+	 * The SMC file format is defined as:
+	 * WHITESPACE: 0x20, \n, \t, \r
+	 * IDENTIFIER: Any ASCII character EXCLUDING ", {, }, ;, //, / *, or WHITESPACE.
+	 * STRING: Any set of symbols enclosed in quotes.
+	 * Note: if a STRING does not have quotes, it is parsed as an IDENTIFIER.
+	 *
+	 * Basic syntax is comprised of SECTIONBLOCKs.
+	 * A SECTIONBLOCK defined as:
+	 *
+	 * SECTIONNAME
+	 * {
+	 *    OPTION
+	 * }
+	 * 
+	 * OPTION can be repeated any number of times inside a SECTIONBLOCK.
+	 * A new line will terminate an OPTION, but there can be more than one OPTION per line.
+	 * OPTION is defined any of:
+	 * 	  "KEY"  "VALUE"
+	 *    SECTIONBLOCK
+	 *
+	 * SECTIONNAME, KEY, VALUE, and SINGLEKEY are strings
+	 * SECTIONNAME cannot have trailing characters if quoted, but the quotes can be optionally removed.
+	 * If SECTIONNAME is not enclosed in quotes, the entire sectionname string is used (minus surrounding whitespace).
+	 * If KEY is not enclosed in quotes, the key is terminated at first whitespace.
+	 * If VALUE is not properly enclosed in quotes, the entire value string is used (minus surrounding whitespace).
+	 * The VALUE may have inner quotes, but the key string may not.
+	 *
+	 * For an example, see configs/permissions.cfg
+	 *
+	 * WHITESPACE should be ignored.
+	 * Comments are text occurring inside the following tokens, and should be stripped
+	 * unless they are inside literal strings:
+	 *  ;<TEXT>
+	 *  //<TEXT>
+	 *  / *<TEXT> */
+
+	/**
+	* @brief Lists actions to take when an SMC parse hook is done.
+	*/
+	enum SMCResult
+	{
+		SMCResult_Continue,		/**< Continue parsing */
+		SMCResult_Halt,			/**< Stop parsing here */
+		SMCResult_HaltFail		/**< Stop parsing and return SMCError_Custom */
+	};
+
+	/**
+	* @brief Lists error codes possible from parsing an SMC file.
+	*/
+	enum SMCError
+	{
+		SMCError_Okay = 0,			/**< No error */
+		SMCError_StreamOpen,		/**< Stream failed to open */
+		SMCError_StreamError,		/**< The stream died... somehow */
+		SMCError_Custom,			/**< A custom handler threw an error */
+		SMCError_InvalidSection1,	/**< A section was declared without quotes, and had extra tokens */
+		SMCError_InvalidSection2,	/**< A section was declared without any header */
+		SMCError_InvalidSection3,	/**< A section ending was declared with too many unknown tokens */
+		SMCError_InvalidSection4,	/**< A section ending has no matching beginning */
+		SMCError_InvalidSection5,	/**< A section beginning has no matching ending */
+		SMCError_InvalidTokens,		/**< There were too many unidentifiable strings on one line */
+		SMCError_TokenOverflow,		/**< The token buffer overflowed */
+		SMCError_InvalidProperty1,	/**< A property was declared outside of any section */
+	};
+
+	/**
+	 * @brief States for line/column
+	 */
+	struct SMCStates
+	{
+		unsigned int line;			/**< Current line */
+		unsigned int col;			/**< Current col */
+	};
+
+	/**
+	 * @brief Describes the events available for reading an SMC stream.
+	 */
+	class ITextListener_SMC
+	{
+	public:
+		/** 
+		 * @brief Returns version number.
+		 */
+		virtual unsigned int GetTextParserVersion2()
+		{
+			return SMINTERFACE_TEXTPARSERS_VERSION;
+		}
+	public:
+		/**
+		 * @brief Called when starting parsing.
+		 */
+		virtual void ReadSMC_ParseStart()
+		{
+		};
+
+		/**
+		 * @brief Called when ending parsing.
+		 *
+		 * @param halted			True if abnormally halted, false otherwise.
+		 * @param failed			True if parsing failed, false otherwise.
+		 */
+		virtual void ReadSMC_ParseEnd(bool halted, bool failed)
+		{
+		}
+
+		/**
+		 * @brief Called when entering a new section
+		 *
+		 * @param states		Parsing states.
+		 * @param name			Name of section, with the colon omitted.
+		 * @return				SMCResult directive.
+		 */
+		virtual SMCResult ReadSMC_NewSection(const SMCStates *states, const char *name)
+		{
+			return SMCResult_Continue;
+		}
+
+		/**
+		 * @brief Called when encountering a key/value pair in a section.
+		 * 
+		 * @param states		Parsing states.
+		 * @param key			Key string.
+		 * @param value			Value string.  If no quotes were specified, this will be NULL, 
+		 *						and key will contain the entire string.
+		 * @return				SMCResult directive.
+		 */
+		virtual SMCResult ReadSMC_KeyValue(const SMCStates *states, const char *key, const char *value)
+		{
+			return SMCResult_Continue;
+		}
+
+		/**
+		 * @brief Called when leaving the current section.
+		 *
+		 * @param states		Parsing states.
+		 * @return				SMCResult directive.
+		 */
+		virtual SMCResult ReadSMC_LeavingSection(const SMCStates *states)
+		{
+			return SMCResult_Continue;
+		}
+
+		/**
+		 * @brief Called after an input line has been preprocessed.
+		 *
+		 * @param states		Parsing states.
+		 * @param line			Contents of the line, null terminated at the position 
+		 * 						of the newline character (thus, no newline will exist).
+		 * @return				SMCResult directive.
+		 */
+		virtual SMCResult ReadSMC_RawLine(const SMCStates *states, const char *line)
+		{
+			return SMCResult_Continue;
+		}
+	};	
+
+	/**
+	 * @brief Contains various text stream parsing functions.
+	 */
+	class ITextParsers /*: public SMInterface*/
+	{
+	public:
+		virtual const char *GetInterfaceName()
+		{
+			return SMINTERFACE_TEXTPARSERS_NAME;
+		}
+		virtual unsigned int GetInterfaceVersion()
+		{
+			return SMINTERFACE_TEXTPARSERS_VERSION;
+		}
+		virtual bool IsVersionCompatible(unsigned int version)
+		{
+			if (version < 2)
+			{
+				return false;
+			}
+
+			return true;
+			/*return SMInterface::IsVersionCompatible(version);*/
+		}
+	public:
+		/**
+		 * @brief Parses an INI-format file.
+		 *
+		 * @param file			Path to file.
+		 * @param ini_listener	Event handler for reading file.
+		 * @param line			If non-NULL, will contain last line parsed (0 if file could not be opened).
+		 * @param col			If non-NULL, will contain last column parsed (undefined if file could not be opened).
+		 * @param inline_comment Whether inline comment is allowed.
+		 * @return				True if parsing succeeded, false if file couldn't be opened or there was a syntax error.
+		 */
+		virtual bool ParseFile_INI(const char *file,
+									ITextListener_INI *ini_listener,
+									unsigned int *line,
+									unsigned int *col,
+									bool inline_comment = true) =0;
+
+		/**
+		 * @brief Parses an SMC-format text file.
+		 * Note that the parser makes every effort to obey broken syntax.
+		 * For example, if an open brace is missing, but the section name has a colon,
+		 * it will let you know.  It is up to the event handlers to decide whether to be strict or not.
+		 *
+		 * @param file			Path to file.
+		 * @param smc_listener	Event handler for reading file.
+		 * @param states		Optional pointer to store last known states.
+		 * @return				An SMCError result code.
+		 */
+		virtual SMCError ParseFile_SMC(const char *file, 
+									ITextListener_SMC *smc_listener, 
+									SMCStates *states) =0;
+
+		/**
+		 * @brief Converts an SMCError to a string.
+		 *
+		 * @param err			SMCError.
+		 * @return				String error message, or NULL if none.
+		 */
+		virtual const char *GetSMCErrorString(SMCError err) =0;
+
+	public:
+		/**
+		 * @brief Returns the number of bytes that a multi-byte character contains in a UTF-8 stream.
+		 * If the current character is not multi-byte, the function returns 1.
+		 *
+		 * @param stream		Pointer to multi-byte ANSI character string.
+		 * @return				Number of bytes in current character.
+		 */
+		virtual unsigned int GetUTF8CharBytes(const char *stream) =0;
+
+		/**
+		 * @brief Returns whether the first multi-byte character in the given stream
+		 * is a whitespace character.
+		 *
+		 * @param stream		Pointer to multi-byte character string.
+		 * @return				True if first character is whitespace, false otherwise.
+		 */
+		virtual bool IsWhitespace(const char *stream) =0;
+
+		/**
+		 * @brief Same as ParseFile_SMC, but with an extended error buffer.
+		 *
+		 * @param file			Path to file.
+		 * @param smc_listener	Event handler for reading file.
+		 * @param states		Optional pointer to store last known states.
+		 * @param buffer		Error message buffer.
+		 * @param maxsize		Maximum size of the error buffer.
+		 * @return 				Error code.
+		 */
+		virtual SMCError ParseSMCFile(const char *file,
+			ITextListener_SMC *smc_listener,
+			SMCStates *states,
+			char *buffer,
+			size_t maxsize) =0;
+
+		/**
+		 * @brief Parses a raw UTF8 stream as an SMC file.
+		 *
+		 * @param stream		Memory containing data.
+		 * @param length		Number of bytes in the stream.
+		 * @param smc_listener	Event handler for reading file.
+		 * @param states		Optional pointer to store last known states.
+		 * @param buffer		Error message buffer.
+		 * @param maxsize		Maximum size of the error buffer.
+		 * @return 				Error code.
+		 */
+		virtual SMCError ParseSMCStream(const char *stream,
+			size_t length,
+			ITextListener_SMC *smc_listener,
+			SMCStates *states,
+			char *buffer,
+			size_t maxsize) =0;
+	};
+
+	inline unsigned int _GetUTF8CharBytes(const char *stream)
+	{
+		unsigned char c = *(unsigned char *)stream;
+		if (c & (1<<7))
+		{
+			if (c & (1<<5))
+			{
+				if (c & (1<<4))
+				{
+					return 4;
+				}
+				return 3;
+			}
+			return 2;
+		}
+		return 1;
+	}
+//}
+
+extern ITextParsers *textparsers;
+
+#endif //_INCLUDE_SOURCEMOD_TEXTPARSERS_INTERFACE_H_
+

--- a/public/amxxsdk/amxxmodule.cpp
+++ b/public/amxxsdk/amxxmodule.cpp
@@ -1,36 +1,16 @@
-/* AMX Mod X
-*
-* by the AMX Mod X Development Team
-*  originally developed by OLO
-*
-* Parts Copyright (C) 2001-2003 Will Day <willday@hpgx.net>
-*
-*  This program is free software; you can redistribute it and/or modify it
-*  under the terms of the GNU General Public License as published by the
-*  Free Software Foundation; either version 2 of the License, or (at
-*  your option) any later version.
-*
-*  This program is distributed in the hope that it will be useful, but
-*  WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-*  General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License
-*  along with this program; if not, write to the Free Software Foundation,
-*  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-*
-*  In addition, as a special exception, the author gives permission to
-*  link the code of this program with the Half-Life Game Engine ("HL
-*  Engine") and Modified Game Libraries ("MODs") developed by Valve,
-*  L.L.C ("Valve"). You must obey the GNU General Public License in all
-*  respects for all of the code used other than the HL Engine and MODs
-*  from Valve. If you modify this file, you may extend this exception
-*  to your version of the file, but you are not obligated to do so. If
-*  you do not wish to do so, delete this exception statement from your
-*  version.
-*
-*  Description: AMX Mod X Module Interface Functions
-*/
+// vim: set ts=4 sw=4 tw=99 noet:
+//
+// AMX Mod X, based on AMX Mod by Aleksander Naszko ("OLO").
+// Copyright (C) The AMX Mod X Development Team.
+// Parts Copyright (C) 2001-2003 Will Day <willday@hpgx.net>
+//
+// This software is licensed under the GNU General Public License, version 3 or higher.
+// Additional exceptions apply. For full license details, see LICENSE.txt or visit:
+//     https://alliedmods.net/amxmodx-license
+
+//
+// Module SDK
+//
 
 #include <string.h>
 #include <new>
@@ -53,7 +33,7 @@ NEW_DLL_FUNCTIONS *g_pNewFunctionsTable;
 NEW_DLL_FUNCTIONS *g_pNewFunctionsTable_Post;
 
 // GetEntityAPI2 functions
-static DLL_FUNCTIONS g_EntityAPI_Table =
+static DLL_FUNCTIONS g_EntityAPI_Table = 
 {
 #ifdef FN_GameDLLInit
 	FN_GameDLLInit,
@@ -307,8 +287,8 @@ static DLL_FUNCTIONS g_EntityAPI_Table =
 #endif
 }; // g_EntityAPI2_Table
 
-   // GetEntityAPI2_Post functions
-static DLL_FUNCTIONS g_EntityAPI_Post_Table =
+// GetEntityAPI2_Post functions
+static DLL_FUNCTIONS g_EntityAPI_Post_Table = 
 {
 #ifdef FN_GameDLLInit_Post
 	FN_GameDLLInit_Post,
@@ -562,7 +542,7 @@ static DLL_FUNCTIONS g_EntityAPI_Post_Table =
 #endif
 }; // g_EntityAPI2_Table
 
-static enginefuncs_t g_EngineFuncs_Table =
+static enginefuncs_t g_EngineFuncs_Table = 
 {
 #ifdef FN_PrecacheModel
 	FN_PrecacheModel,
@@ -2012,7 +1992,7 @@ static enginefuncs_t g_EngineFuncs_Post_Table =
 }; // g_EngineFuncs_Post_Table
 
 
-static NEW_DLL_FUNCTIONS g_NewFuncs_Table =
+static NEW_DLL_FUNCTIONS g_NewFuncs_Table = 
 {
 #ifdef FN_OnFreeEntPrivateData
 	FN_OnFreeEntPrivateData,
@@ -2032,7 +2012,7 @@ static NEW_DLL_FUNCTIONS g_NewFuncs_Table =
 };
 
 
-static NEW_DLL_FUNCTIONS g_NewFuncs_Post_Table =
+static NEW_DLL_FUNCTIONS g_NewFuncs_Post_Table = 
 {
 #ifdef FN_OnFreeEntPrivateData_Post
 	FN_OnFreeEntPrivateData_Post,
@@ -2059,165 +2039,171 @@ mutil_funcs_t *gpMetaUtilFuncs;		// metamod utility functions
 
 
 plugin_info_t Plugin_info = {
-	META_INTERFACE_VERSION,
-	MODULE_NAME,
-	MODULE_VERSION,
-	MODULE_DATE,
-	MODULE_AUTHOR,
-	MODULE_URL,
-	MODULE_LOGTAG,
-	PT_ANYTIME,
-	PT_ANYTIME
+		META_INTERFACE_VERSION,
+		MODULE_NAME,
+		MODULE_VERSION,
+		MODULE_DATE,
+		MODULE_AUTHOR,
+		MODULE_URL,
+		MODULE_LOGTAG,
+		PT_ANYTIME,
+		PT_ANYTIME
 };
 
 /*
 C_DLLEXPORT int GetEntityAPI(DLL_FUNCTIONS *pFunctionTable, int interfaceVersion)
 {
-LOG_DEVELOPER(PLID, "called: GetEntityAPI; version=%d", interfaceVersion);
-if(!pFunctionTable) {
-LOG_ERROR(PLID, "GetEntityAPI called with null pFunctionTable");
-return(FALSE);
-}
-else if(interfaceVersion != INTERFACE_VERSION) {
-LOG_ERROR(PLID, "GetEntityAPI version mismatch; requested=%d ours=%d", interfaceVersion, INTERFACE_VERSION);
-return(FALSE);
-}
-memcpy(pFunctionTable, &g_EntityAPI_Table, sizeof( DLL_FUNCTIONS ) );
+	LOG_DEVELOPER(PLID, "called: GetEntityAPI; version=%d", interfaceVersion);
+	if(!pFunctionTable) {
+		LOG_ERROR(PLID, "GetEntityAPI called with null pFunctionTable");
+		return(FALSE);
+	}
+	else if(interfaceVersion != INTERFACE_VERSION) {
+		LOG_ERROR(PLID, "GetEntityAPI version mismatch; requested=%d ours=%d", interfaceVersion, INTERFACE_VERSION);
+		return(FALSE);
+	}
+	memcpy(pFunctionTable, &g_EntityAPI_Table, sizeof( DLL_FUNCTIONS ) );
 
-return (TRUE);
+	return (TRUE);
 }
 
 C_DLLEXPORT int GetEntityAPI_Post(DLL_FUNCTIONS *pFunctionTable, int interfaceVersion)
 {
-LOG_DEVELOPER(PLID, "called: GetEntityAPI_Post; version=%d", interfaceVersion);
-if(!pFunctionTable) {
-LOG_ERROR(PLID, "GetEntityAPI_Post called with null pFunctionTable");
-return(FALSE);
-}
-else if(interfaceVersion != INTERFACE_VERSION) {
-LOG_ERROR(PLID, "GetEntityAPI_Post version mismatch; requested=%d ours=%d", interfaceVersion, INTERFACE_VERSION);
-return(FALSE);
-}
-memcpy(pFunctionTable, &g_EntityAPI_Post_Table, sizeof( DLL_FUNCTIONS ) );
+	LOG_DEVELOPER(PLID, "called: GetEntityAPI_Post; version=%d", interfaceVersion);
+	if(!pFunctionTable) {
+		LOG_ERROR(PLID, "GetEntityAPI_Post called with null pFunctionTable");
+		return(FALSE);
+	}
+	else if(interfaceVersion != INTERFACE_VERSION) {
+		LOG_ERROR(PLID, "GetEntityAPI_Post version mismatch; requested=%d ours=%d", interfaceVersion, INTERFACE_VERSION);
+		return(FALSE);
+	}
+	memcpy(pFunctionTable, &g_EntityAPI_Post_Table, sizeof( DLL_FUNCTIONS ) );
 
-return(TRUE);
+	return(TRUE);
 }
 */
 
-C_DLLEXPORT int GetEntityAPI2(DLL_FUNCTIONS *pFunctionTable, int *interfaceVersion) {
+C_DLLEXPORT int GetEntityAPI2(DLL_FUNCTIONS *pFunctionTable, int *interfaceVersion)
+{
 	LOG_DEVELOPER(PLID, "called: GetEntityAPI2; version=%d", *interfaceVersion);
-	if (!pFunctionTable) {
+	if(!pFunctionTable) {
 		LOG_ERROR(PLID, "GetEntityAPI2 called with null pFunctionTable");
 		return(FALSE);
 	}
-	else if (*interfaceVersion != INTERFACE_VERSION) {
-		LOG_ERROR(PLID,
-			"GetEntityAPI2 version mismatch; requested=%d ours=%d",
-			*interfaceVersion, INTERFACE_VERSION);
+	else if(*interfaceVersion != INTERFACE_VERSION) {
+		LOG_ERROR(PLID, 
+				"GetEntityAPI2 version mismatch; requested=%d ours=%d", 
+				*interfaceVersion, INTERFACE_VERSION);
 		//! Tell engine what version we had, so it can figure out who is 
 		//! out of date.
 		*interfaceVersion = INTERFACE_VERSION;
 		return(FALSE);
 	}
 	memcpy(pFunctionTable, &g_EntityAPI_Table, sizeof(DLL_FUNCTIONS));
-	g_pFunctionTable = pFunctionTable;
+	g_pFunctionTable=pFunctionTable;
 	return(TRUE);
 }
 
-C_DLLEXPORT int GetEntityAPI2_Post(DLL_FUNCTIONS *pFunctionTable, int *interfaceVersion) {
+C_DLLEXPORT int GetEntityAPI2_Post(DLL_FUNCTIONS *pFunctionTable, int *interfaceVersion)
+{
 	LOG_DEVELOPER(PLID, "called: GetEntityAPI2_Post; version=%d", *interfaceVersion);
-	if (!pFunctionTable) {
+	if(!pFunctionTable) {
 		LOG_ERROR(PLID, "GetEntityAPI2_Post called with null pFunctionTable");
 		return(FALSE);
 	}
-	else if (*interfaceVersion != INTERFACE_VERSION) {
+	else if(*interfaceVersion != INTERFACE_VERSION) {
 		LOG_ERROR(PLID, "GetEntityAPI2_Post version mismatch; requested=%d ours=%d", *interfaceVersion, INTERFACE_VERSION);
 		//! Tell engine what version we had, so it can figure out who is out of date.
 		*interfaceVersion = INTERFACE_VERSION;
 		return(FALSE);
 	}
-	memcpy(pFunctionTable, &g_EntityAPI_Post_Table, sizeof(DLL_FUNCTIONS));
-	g_pFunctionTable_Post = pFunctionTable;
+	memcpy( pFunctionTable, &g_EntityAPI_Post_Table, sizeof( DLL_FUNCTIONS ) );
+	g_pFunctionTable_Post=pFunctionTable;
 	return(TRUE);
 }
 
-C_DLLEXPORT int GetEngineFunctions(enginefuncs_t *pengfuncsFromEngine, int *interfaceVersion) {
-	LOG_DEVELOPER(PLID, "called: GetEngineFunctions; version=%d",
-		*interfaceVersion);
-	if (!pengfuncsFromEngine) {
-		LOG_ERROR(PLID,
-			"GetEngineFunctions called with null pengfuncsFromEngine");
+C_DLLEXPORT int GetEngineFunctions(enginefuncs_t *pengfuncsFromEngine, int *interfaceVersion)
+{
+	LOG_DEVELOPER(PLID, "called: GetEngineFunctions; version=%d", 
+			*interfaceVersion);
+	if(!pengfuncsFromEngine) {
+		LOG_ERROR(PLID, 
+				"GetEngineFunctions called with null pengfuncsFromEngine");
 		return(FALSE);
 	}
-	else if (*interfaceVersion != ENGINE_INTERFACE_VERSION) {
-		LOG_ERROR(PLID,
-			"GetEngineFunctions version mismatch; requested=%d ours=%d",
-			*interfaceVersion, ENGINE_INTERFACE_VERSION);
+	else if(*interfaceVersion != ENGINE_INTERFACE_VERSION) {
+		LOG_ERROR(PLID, 
+				"GetEngineFunctions version mismatch; requested=%d ours=%d", 
+				*interfaceVersion, ENGINE_INTERFACE_VERSION);
 		// Tell metamod what version we had, so it can figure out who is 
 		// out of date.
 		*interfaceVersion = ENGINE_INTERFACE_VERSION;
 		return(FALSE);
 	}
 	memcpy(pengfuncsFromEngine, &g_EngineFuncs_Table, sizeof(enginefuncs_t));
-	g_pengfuncsTable = pengfuncsFromEngine;
+	g_pengfuncsTable=pengfuncsFromEngine;
 	return TRUE;
 }
 
-C_DLLEXPORT int GetEngineFunctions_Post(enginefuncs_t *pengfuncsFromEngine, int *interfaceVersion) {
+C_DLLEXPORT int GetEngineFunctions_Post(enginefuncs_t *pengfuncsFromEngine, int *interfaceVersion)
+{
 	LOG_DEVELOPER(PLID, "called: GetEngineFunctions_Post; version=%d", *interfaceVersion);
-	if (!pengfuncsFromEngine) {
+	if(!pengfuncsFromEngine) {
 		LOG_ERROR(PLID, "GetEngineFunctions_Post called with null pengfuncsFromEngine");
 		return(FALSE);
 	}
-	else if (*interfaceVersion != ENGINE_INTERFACE_VERSION) {
+	else if(*interfaceVersion != ENGINE_INTERFACE_VERSION) {
 		LOG_ERROR(PLID, "GetEngineFunctions_Post version mismatch; requested=%d ours=%d", *interfaceVersion, ENGINE_INTERFACE_VERSION);
 		// Tell metamod what version we had, so it can figure out who is out of date.
 		*interfaceVersion = ENGINE_INTERFACE_VERSION;
 		return(FALSE);
 	}
 	memcpy(pengfuncsFromEngine, &g_EngineFuncs_Post_Table, sizeof(enginefuncs_t));
-	g_pengfuncsTable_Post = pengfuncsFromEngine;
+	g_pengfuncsTable_Post=pengfuncsFromEngine;
 	return TRUE;
 
 }
 
-C_DLLEXPORT int GetNewDLLFunctions(NEW_DLL_FUNCTIONS *pNewFunctionTable,
-	int *interfaceVersion) {
-	LOG_DEVELOPER(PLID, "called: GetNewDLLFunctions; version=%d",
-		*interfaceVersion);
-	if (!pNewFunctionTable) {
-		LOG_ERROR(PLID,
-			"GetNewDLLFunctions called with null pNewFunctionTable");
+C_DLLEXPORT int GetNewDLLFunctions(NEW_DLL_FUNCTIONS *pNewFunctionTable, 
+		int *interfaceVersion) 
+{
+	LOG_DEVELOPER(PLID, "called: GetNewDLLFunctions; version=%d", 
+			*interfaceVersion);
+	if(!pNewFunctionTable) {
+		LOG_ERROR(PLID, 
+				"GetNewDLLFunctions called with null pNewFunctionTable");
 		return(FALSE);
 	}
-	else if (*interfaceVersion != NEW_DLL_FUNCTIONS_VERSION) {
-		LOG_ERROR(PLID,
-			"GetNewDLLFunctions version mismatch; requested=%d ours=%d",
-			*interfaceVersion, NEW_DLL_FUNCTIONS_VERSION);
+	else if(*interfaceVersion != NEW_DLL_FUNCTIONS_VERSION) {
+		LOG_ERROR(PLID, 
+				"GetNewDLLFunctions version mismatch; requested=%d ours=%d", 
+				*interfaceVersion, NEW_DLL_FUNCTIONS_VERSION);
 		//! Tell engine what version we had, so it can figure out who is 
 		//! out of date.
 		*interfaceVersion = NEW_DLL_FUNCTIONS_VERSION;
 		return(FALSE);
 	}
 	memcpy(pNewFunctionTable, &g_NewFuncs_Table, sizeof(NEW_DLL_FUNCTIONS));
-	g_pNewFunctionsTable = pNewFunctionTable;
+	g_pNewFunctionsTable=pNewFunctionTable;
 	return TRUE;
 }
 
-C_DLLEXPORT int GetNewDLLFunctions_Post(NEW_DLL_FUNCTIONS *pNewFunctionTable, int *interfaceVersion) {
+C_DLLEXPORT int GetNewDLLFunctions_Post( NEW_DLL_FUNCTIONS *pNewFunctionTable, int *interfaceVersion ) 
+{
 	LOG_DEVELOPER(PLID, "called: GetNewDLLFunctions_Post; version=%d", *interfaceVersion);
-	if (!pNewFunctionTable) {
+	if(!pNewFunctionTable) {
 		LOG_ERROR(PLID, "GetNewDLLFunctions_Post called with null pNewFunctionTable");
 		return(FALSE);
 	}
-	else if (*interfaceVersion != NEW_DLL_FUNCTIONS_VERSION) {
+	else if(*interfaceVersion != NEW_DLL_FUNCTIONS_VERSION) {
 		LOG_ERROR(PLID, "GetNewDLLFunctions_Post version mismatch; requested=%d ours=%d", *interfaceVersion, NEW_DLL_FUNCTIONS_VERSION);
 		//! Tell engine what version we had, so it can figure out who is out of date.
 		*interfaceVersion = NEW_DLL_FUNCTIONS_VERSION;
 		return(FALSE);
 	}
 	memcpy(pNewFunctionTable, &g_NewFuncs_Post_Table, sizeof(NEW_DLL_FUNCTIONS));
-	g_pNewFunctionsTable_Post = pNewFunctionTable;
+	g_pNewFunctionsTable_Post=pNewFunctionTable;
 	return TRUE;
 }
 
@@ -2234,13 +2220,14 @@ static META_FUNCTIONS g_MetaFunctions_Table =
 	GetEngineFunctions_Post
 };
 
-C_DLLEXPORT int Meta_Query(const char *ifvers, plugin_info_t **pPlugInfo, mutil_funcs_t *pMetaUtilFuncs) {
-	if ((int)CVAR_GET_FLOAT("developer") != 0)
-		UTIL_LogPrintf("[%s] dev: called: Meta_Query; version=%s, ours=%s\n",
-			Plugin_info.logtag, ifvers, Plugin_info.ifvers);
+C_DLLEXPORT int Meta_Query(const char *ifvers, plugin_info_t **pPlugInfo, mutil_funcs_t *pMetaUtilFuncs)
+{
+	if ((int) CVAR_GET_FLOAT("developer") != 0)
+		UTIL_LogPrintf("[%s] dev: called: Meta_Query; version=%s, ours=%s\n", 
+				Plugin_info.logtag, ifvers, Plugin_info.ifvers);
 
 	// Check for valid pMetaUtilFuncs before we continue.
-	if (!pMetaUtilFuncs) {
+	if(!pMetaUtilFuncs) {
 		UTIL_LogPrintf("[%s] ERROR: Meta_Query called with null pMetaUtilFuncs\n", Plugin_info.logtag);
 		return(FALSE);
 	}
@@ -2250,27 +2237,27 @@ C_DLLEXPORT int Meta_Query(const char *ifvers, plugin_info_t **pPlugInfo, mutil_
 	*pPlugInfo = &Plugin_info;
 
 	// Check for interface version compatibility.
-	if (!FStrEq(ifvers, Plugin_info.ifvers)) {
-		int mmajor = 0, mminor = 0, pmajor = 0, pminor = 0;
+	if(!FStrEq(ifvers, Plugin_info.ifvers)) {
+		int mmajor=0, mminor=0, pmajor=0, pminor=0;
 		LOG_MESSAGE(PLID, "WARNING: meta-interface version mismatch; requested=%s ours=%s",
-			Plugin_info.logtag, ifvers);
+				Plugin_info.logtag, ifvers);
 		// If plugin has later interface version, it's incompatible (update
 		// metamod).
 		sscanf(ifvers, "%d:%d", &mmajor, &mminor);
 		sscanf(META_INTERFACE_VERSION, "%d:%d", &pmajor, &pminor);
-		if (pmajor > mmajor || (pmajor == mmajor && pminor > mminor)) {
+		if(pmajor > mmajor || (pmajor==mmajor && pminor > mminor)) {
 			LOG_ERROR(PLID, "metamod version is too old for this module; update metamod");
 			return(FALSE);
 		}
 		// If plugin has older major interface version, it's incompatible
 		// (update plugin).
-		else if (pmajor < mmajor) {
+		else if(pmajor < mmajor) {
 			LOG_ERROR(PLID, "metamod version is incompatible with this module; please find a newer version of this module");
 			return(FALSE);
 		}
 		// Minor interface is older, but this is guaranteed to be backwards
 		// compatible, so we warn, but we still accept it.
-		else if (pmajor == mmajor && pminor < mminor)
+		else if(pmajor==mmajor && pminor < mminor)
 			LOG_MESSAGE(PLID, "WARNING: metamod version is newer than expected; consider finding a newer version of this module");
 		else
 			LOG_ERROR(PLID, "unexpected version comparison; metavers=%s, mmajor=%d, mminor=%d; plugvers=%s, pmajor=%d, pminor=%d", ifvers, mmajor, mminor, META_INTERFACE_VERSION, pmajor, pminor);
@@ -2284,23 +2271,24 @@ C_DLLEXPORT int Meta_Query(const char *ifvers, plugin_info_t **pPlugInfo, mutil_
 }
 
 
-C_DLLEXPORT int Meta_Attach(PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable, meta_globals_t *pMGlobals, gamedll_funcs_t *pGamedllFuncs) {
-	if (now > Plugin_info.loadable) {
+C_DLLEXPORT int Meta_Attach(PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable, meta_globals_t *pMGlobals, gamedll_funcs_t *pGamedllFuncs)
+{
+	if(now > Plugin_info.loadable) {
 		LOG_ERROR(PLID, "Can't load module right now");
 		return(FALSE);
 	}
-	if (!pMGlobals) {
+	if(!pMGlobals) {
 		LOG_ERROR(PLID, "Meta_Attach called with null pMGlobals");
 		return(FALSE);
 	}
-	gpMetaGlobals = pMGlobals;
-	if (!pFunctionTable) {
+	gpMetaGlobals=pMGlobals;
+	if(!pFunctionTable) {
 		LOG_ERROR(PLID, "Meta_Attach called with null pFunctionTable");
 		return(FALSE);
 	}
 
 	memcpy(pFunctionTable, &g_MetaFunctions_Table, sizeof(META_FUNCTIONS));
-	gpGamedllFuncs = pGamedllFuncs;
+	gpGamedllFuncs=pGamedllFuncs;
 
 	// Let's go.
 
@@ -2311,8 +2299,9 @@ C_DLLEXPORT int Meta_Attach(PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable, m
 	return TRUE;
 }
 
-C_DLLEXPORT int Meta_Detach(PLUG_LOADTIME now, PL_UNLOAD_REASON reason) {
-	if (now > Plugin_info.unloadable && reason != PNL_CMD_FORCED) {
+C_DLLEXPORT int Meta_Detach(PLUG_LOADTIME now, PL_UNLOAD_REASON reason)
+{
+	if(now > Plugin_info.unloadable && reason != PNL_CMD_FORCED) {
 		LOG_ERROR(PLID, "Can't unload plugin right now");
 		return(FALSE);
 	}
@@ -2323,82 +2312,10 @@ C_DLLEXPORT int Meta_Detach(PLUG_LOADTIME now, PL_UNLOAD_REASON reason) {
 	return TRUE;
 }
 
-
-
-#if defined(__linux__) || defined(__APPLE__)
-// linux prototype
-C_DLLEXPORT void GiveFnptrsToDll(enginefuncs_t* pengfuncsFromEngine, globalvars_t *pGlobals) {
-
-#else
-#ifdef _MSC_VER
-// MSVC: Simulate __stdcall calling convention
-C_DLLEXPORT __declspec(naked) void GiveFnptrsToDll(enginefuncs_t* pengfuncsFromEngine, globalvars_t *pGlobals) {
-	__asm			// Prolog
-	{
-		// Save ebp
-		push		ebp
-		// Set stack frame pointer
-			mov			ebp, esp
-			// Allocate space for local variables
-			// The MSVC compiler gives us the needed size in __LOCAL_SIZE.
-			sub			esp, __LOCAL_SIZE
-			// Push registers
-			push		ebx
-			push		esi
-			push		edi
-	}
-#else	// _MSC_VER
-#ifdef __GNUC__
-// GCC can also work with this
-C_DLLEXPORT void __stdcall GiveFnptrsToDll(enginefuncs_t* pengfuncsFromEngine, globalvars_t *pGlobals) {
-#else	// __GNUC__
-// compiler not known
-#error There is no support (yet) for your compiler. Please use MSVC or GCC compilers or contact the AMX Mod X dev team.
-#endif	// __GNUC__
-#endif // _MSC_VER
-#endif // __linux__
-
-// ** Function core <--
-memcpy(&g_engfuncs, pengfuncsFromEngine, sizeof(enginefuncs_t));
-gpGlobals = pGlobals;
-// NOTE!  Have to call logging function _after_ copying into g_engfuncs, so
-// that g_engfuncs.pfnAlertMessage() can be resolved properly, heh. :)
-// UTIL_LogPrintf("[%s] dev: called: GiveFnptrsToDll\n", Plugin_info.logtag);
-// --> ** Function core
-
-#ifdef _MSC_VER
-// Epilog
-if (sizeof(int*) == 8) {	// 64 bit
-	__asm
-	{
-		// Pop registers
-		pop	edi
-		pop	esi
-			pop	ebx
-			// Restore stack frame pointer
-			mov	esp, ebp
-			// Restore ebp
-			pop	ebp
-			// 2 * sizeof(int*) = 16 on 64 bit
-			ret 16
-	}
-}
-else {	// 32 bit
-	__asm
-	{
-		// Pop registers
-		pop	edi
-		pop	esi
-			pop	ebx
-			// Restore stack frame pointer
-			mov	esp, ebp
-			// Restore ebp
-			pop	ebp
-			// 2 * sizeof(int*) = 8 on 32 bit
-			ret 8
-	}
-}
-#endif // #ifdef _MSC_VER
+C_DLLEXPORT void WINAPI GiveFnptrsToDll(enginefuncs_t* pengfuncsFromEngine, globalvars_t *pGlobals)
+{
+	memcpy(&g_engfuncs, pengfuncsFromEngine, sizeof(enginefuncs_t));
+	gpGlobals = pGlobals;
 }
 
 #endif	// #ifdef USE_METAMOD
@@ -2407,7 +2324,7 @@ else {	// 32 bit
 
 // *** Globals ***
 // Module info
-static amxx_module_info_s g_ModuleInfo =
+static amxx_module_info_s g_ModuleInfo = 
 {
 	MODULE_NAME,
 	MODULE_AUTHOR,
@@ -2428,6 +2345,7 @@ PFN_ADD_NEW_NATIVES			g_fn_AddNewNatives;
 PFN_BUILD_PATHNAME			g_fn_BuildPathname;
 PFN_BUILD_PATHNAME_R		g_fn_BuildPathnameR;
 PFN_GET_AMXADDR				g_fn_GetAmxAddr;
+PFN_GET_AMXVECTOR_NULL		g_fn_GetAmxVectorNull;
 PFN_PRINT_SRVCONSOLE		g_fn_PrintSrvConsole;
 PFN_GET_MODNAME				g_fn_GetModname;
 PFN_GET_AMXSCRIPTNAME		g_fn_GetAmxScriptName;
@@ -2435,7 +2353,10 @@ PFN_GET_AMXSCRIPT			g_fn_GetAmxScript;
 PFN_FIND_AMXSCRIPT_BYAMX	g_fn_FindAmxScriptByAmx;
 PFN_FIND_AMXSCRIPT_BYNAME	g_fn_FindAmxScriptByName;
 PFN_SET_AMXSTRING			g_fn_SetAmxString;
+PFN_SET_AMXSTRING_UTF8_CHAR	g_fn_SetAmxStringUTF8Char;
+PFN_SET_AMXSTRING_UTF8_CELL	g_fn_SetAmxStringUTF8Cell;
 PFN_GET_AMXSTRING			g_fn_GetAmxString;
+PFN_GET_AMXSTRING_NULL		g_fn_GetAmxStringNull;
 PFN_GET_AMXSTRINGLEN		g_fn_GetAmxStringLen;
 PFN_FORMAT_AMXSTRING		g_fn_FormatAmxString;
 PFN_COPY_AMXMEMORY			g_fn_CopyAmxMemory;
@@ -2478,6 +2399,7 @@ PFN_AMX_EXECV				g_fn_AmxExecv;
 PFN_AMX_ALLOT				g_fn_AmxAllot;
 PFN_AMX_FINDPUBLIC			g_fn_AmxFindPublic;
 PFN_LOAD_AMXSCRIPT			g_fn_LoadAmxScript;
+PFN_LOAD_AMXSCRIPT_EX		g_fn_LoadAmxScriptEx;
 PFN_UNLOAD_AMXSCRIPT		g_fn_UnloadAmxScript;
 PFN_REAL_TO_CELL			g_fn_RealToCell;
 PFN_CELL_TO_REAL			g_fn_CellToReal;
@@ -2504,15 +2426,18 @@ PFN_GETLOCALINFO			g_fn_GetLocalInfo;
 PFN_AMX_REREGISTER			g_fn_AmxReRegister;
 PFN_REGISTERFUNCTIONEX		g_fn_RegisterFunctionEx;
 PFN_MESSAGE_BLOCK			g_fn_MessageBlock;
+PFN_GET_CONFIG_MANAGER		g_fn_GetConfigManager;
 
 // *** Exports ***
-C_DLLEXPORT int AMXX_Query(int *interfaceVersion, amxx_module_info_s *moduleInfo) {
+C_DLLEXPORT int AMXX_Query(int *interfaceVersion, amxx_module_info_s *moduleInfo)
+{
 	// check parameters
 	if (!interfaceVersion || !moduleInfo)
 		return AMXX_PARAM;
 
 	// check interface version
-	if (*interfaceVersion != AMXX_INTERFACE_VERSION) {
+	if (*interfaceVersion != AMXX_INTERFACE_VERSION)
+	{
 		// Tell amxx core our interface version
 		*interfaceVersion = AMXX_INTERFACE_VERSION;
 		return AMXX_IFVERS;
@@ -2533,14 +2458,16 @@ C_DLLEXPORT int AMXX_Query(int *interfaceVersion, amxx_module_info_s *moduleInfo
 // request optional function
 #define REQFUNC_OPT(name, fptr, type) fptr = (type)reqFnptrFunc(name)
 
-C_DLLEXPORT int AMXX_CheckGame(const char *game) {
+C_DLLEXPORT int AMXX_CheckGame(const char *game)
+{
 #ifdef FN_AMXX_CHECKGAME
 	return FN_AMXX_CHECKGAME(game);
 #else
 	return AMXX_GAME_OK;
 #endif
 }
-C_DLLEXPORT int AMXX_Attach(PFN_REQ_FNPTR reqFnptrFunc) {
+C_DLLEXPORT int AMXX_Attach(PFN_REQ_FNPTR reqFnptrFunc)
+{
 	// Check pointer
 	if (!reqFnptrFunc)
 		return AMXX_PARAM;
@@ -2559,22 +2486,28 @@ C_DLLEXPORT int AMXX_Attach(PFN_REQ_FNPTR reqFnptrFunc) {
 	REQFUNC("Format", g_fn_Format, PFN_FORMAT);
 	REQFUNC("RegisterFunction", g_fn_RegisterFunction, PFN_REGISTERFUNCTION);
 	REQFUNC("RegisterFunctionEx", g_fn_RegisterFunctionEx, PFN_REGISTERFUNCTIONEX);
+	REQFUNC("GetConfigManager", g_fn_GetConfigManager, PFN_GET_CONFIG_MANAGER);
 
 	// Amx scripts
 	REQFUNC("GetAmxScript", g_fn_GetAmxScript, PFN_GET_AMXSCRIPT);
 	REQFUNC("FindAmxScriptByAmx", g_fn_FindAmxScriptByAmx, PFN_FIND_AMXSCRIPT_BYAMX);
 	REQFUNC("FindAmxScriptByName", g_fn_FindAmxScriptByName, PFN_FIND_AMXSCRIPT_BYNAME);
-	REQFUNC("LoadAmxScript", g_fn_LoadAmxScript, PFN_LOAD_AMXSCRIPT);
+	REQFUNC("LoadAmxScript", g_fn_LoadAmxScript, PFN_LOAD_AMXSCRIPT); // Deprecated. Please use LoadAmxScriptEx instead.
+	REQFUNC("LoadAmxScriptEx", g_fn_LoadAmxScriptEx, PFN_LOAD_AMXSCRIPT_EX);
 	REQFUNC("UnloadAmxScript", g_fn_UnloadAmxScript, PFN_UNLOAD_AMXSCRIPT);
-	REQFUNC("GetAmxScriptName", g_fn_GetAmxScriptName, PFN_GET_AMXSCRIPTNAME);
+    REQFUNC("GetAmxScriptName", g_fn_GetAmxScriptName, PFN_GET_AMXSCRIPTNAME);
 
 	// String / mem in amx scripts support
 	REQFUNC("SetAmxString", g_fn_SetAmxString, PFN_SET_AMXSTRING);
+	REQFUNC("SetAmxStringUTF8Char", g_fn_SetAmxStringUTF8Char, PFN_SET_AMXSTRING_UTF8_CHAR);
+	REQFUNC("SetAmxStringUTF8Cell", g_fn_SetAmxStringUTF8Cell, PFN_SET_AMXSTRING_UTF8_CELL);
 	REQFUNC("GetAmxString", g_fn_GetAmxString, PFN_GET_AMXSTRING);
+	REQFUNC("GetAmxStringNull", g_fn_GetAmxStringNull, PFN_GET_AMXSTRING_NULL);
 	REQFUNC("GetAmxStringLen", g_fn_GetAmxStringLen, PFN_GET_AMXSTRINGLEN);
 	REQFUNC("FormatAmxString", g_fn_FormatAmxString, PFN_FORMAT_AMXSTRING);
 	REQFUNC("CopyAmxMemory", g_fn_CopyAmxMemory, PFN_COPY_AMXMEMORY);
 	REQFUNC("GetAmxAddr", g_fn_GetAmxAddr, PFN_GET_AMXADDR);
+	REQFUNC("GetAmxVectorNull", g_fn_GetAmxVectorNull, PFN_GET_AMXVECTOR_NULL);
 
 	REQFUNC("amx_Exec", g_fn_AmxExec, PFN_AMX_EXEC);
 	REQFUNC("amx_Execv", g_fn_AmxExecv, PFN_AMX_EXECV);
@@ -2599,14 +2532,14 @@ C_DLLEXPORT int AMXX_Attach(PFN_REQ_FNPTR reqFnptrFunc) {
 	REQFUNC("IsPlayerValid", g_fn_IsPlayerValid, PFN_IS_PLAYER_VALID);
 	REQFUNC("GetPlayerName", g_fn_GetPlayerName, PFN_GET_PLAYER_NAME);
 	REQFUNC("GetPlayerIP", g_fn_GetPlayerIP, PFN_GET_PLAYER_IP);
-	REQFUNC("IsPlayerInGame", g_fn_IsPlayerIngame, PFN_IS_PLAYER_INGAME);
-	REQFUNC("IsPlayerBot", g_fn_IsPlayerBot, PFN_IS_PLAYER_BOT);
+	REQFUNC("IsPlayerInGame", g_fn_IsPlayerIngame, PFN_IS_PLAYER_INGAME);		
+	REQFUNC("IsPlayerBot", g_fn_IsPlayerBot, PFN_IS_PLAYER_BOT);	
 	REQFUNC("IsPlayerAuthorized", g_fn_IsPlayerAuthorized, PFN_IS_PLAYER_AUTHORIZED);
 	REQFUNC("GetPlayerTime", g_fn_GetPlayerTime, PFN_GET_PLAYER_TIME);
 	REQFUNC("GetPlayerPlayTime", g_fn_GetPlayerPlayTime, PFN_GET_PLAYER_PLAYTIME);
 	REQFUNC("GetPlayerCurweapon", g_fn_GetPlayerCurweapon, PFN_GET_PLAYER_CURWEAPON);
 	REQFUNC("GetPlayerTeamID", g_fn_GetPlayerTeamID, PFN_GET_PLAYER_TEAMID);
-	REQFUNC("GetPlayerTeam", g_fn_GetPlayerTeam, PFN_GET_PLAYER_TEAM);
+	REQFUNC("GetPlayerTeam",g_fn_GetPlayerTeam, PFN_GET_PLAYER_TEAM);
 	REQFUNC("GetPlayerDeaths", g_fn_GetPlayerDeaths, PFN_GET_PLAYER_DEATHS);
 	REQFUNC("GetPlayerMenu", g_fn_GetPlayerMenu, PFN_GET_PLAYER_MENU);
 	REQFUNC("GetPlayerKeys", g_fn_GetPlayerKeys, PFN_GET_PLAYER_KEYS);
@@ -2651,7 +2584,8 @@ C_DLLEXPORT int AMXX_Attach(PFN_REQ_FNPTR reqFnptrFunc) {
 	return AMXX_OK;
 }
 
-C_DLLEXPORT int AMXX_Detach() {
+C_DLLEXPORT int AMXX_Detach()
+{
 #ifdef FN_AMXX_DETACH
 	FN_AMXX_DETACH();
 #endif // FN_AMXX_DETACH
@@ -2659,27 +2593,31 @@ C_DLLEXPORT int AMXX_Detach() {
 	return AMXX_OK;
 }
 
-C_DLLEXPORT int AMXX_PluginsLoaded() {
+C_DLLEXPORT int AMXX_PluginsLoaded()
+{
 #ifdef FN_AMXX_PLUGINSLOADED
 	FN_AMXX_PLUGINSLOADED();
 #endif // FN_AMXX_PLUGINSLOADED
 	return AMXX_OK;
 }
 
-C_DLLEXPORT void AMXX_PluginsUnloaded() {
+C_DLLEXPORT void AMXX_PluginsUnloaded()
+{
 #ifdef FN_AMXX_PLUGINSUNLOADED
 	FN_AMXX_PLUGINSUNLOADED();
 #endif // FN_AMXX_PLUGINSUNLOADED
 }
 
-C_DLLEXPORT void AMXX_PluginsUnloading() {
+C_DLLEXPORT void AMXX_PluginsUnloading()
+{
 #ifdef FN_AMXX_PLUGINSUNLOADING
 	FN_AMXX_PLUGINSUNLOADING();
 #endif // FN_AMXX_PLUGINSUNLOADING
 }
 
 // Advanced MF functions
-void MF_Log(const char *fmt, ...) {
+void MF_Log(const char *fmt, ...)
+{
 	char msg[3072];
 	va_list arglst;
 	va_start(arglst, fmt);
@@ -2689,7 +2627,8 @@ void MF_Log(const char *fmt, ...) {
 	g_fn_Log("[%s] %s", MODULE_LOGTAG, msg);
 }
 
-void MF_LogError(AMX *amx, int err, const char *fmt, ...) {
+void MF_LogError(AMX *amx, int err, const char *fmt, ...)
+{
 	char msg[3072];
 	va_list arglst;
 	va_start(arglst, fmt);
@@ -2703,11 +2642,14 @@ void MF_LogError(AMX *amx, int err, const char *fmt, ...) {
 #ifdef _DEBUG
 // validate macros
 // Makes sure compiler reports errors when macros are invalid
-void ValidateMacros_DontCallThis_Smiley() {
+void ValidateMacros_DontCallThis_Smiley()
+{
+	const cell str[] = { 's', 't', 'r', '\0' };
 	MF_BuildPathname("str", "str", 0);
 	MF_BuildPathnameR(NULL, 0, "%d", 0);
 	MF_FormatAmxString(NULL, 0, 0, NULL);
 	MF_GetAmxAddr(NULL, 0);
+	MF_GetAmxVectorNull(NULL, 0);
 	MF_PrintSrvConsole("str", "str", 0);
 	MF_GetModname();
 	MF_GetScriptName(0);
@@ -2715,7 +2657,10 @@ void ValidateMacros_DontCallThis_Smiley() {
 	MF_FindScriptByAmx(NULL);
 	MF_FindScriptByName("str");
 	MF_SetAmxString(NULL, 0, "str", 0);
-	MF_GetAmxString(NULL, 0, 0, 0);
+	MF_SetAmxStringUTF8Char(NULL, 0, "str", 0, 0);
+	MF_SetAmxStringUTF8Cell(NULL, 0, str, 0, 0);
+	MF_GetAmxString(NULL, 0, 0, NULL);
+	MF_GetAmxStringNull(NULL, 0, 0, NULL);
 	MF_GetAmxStringLen(NULL);
 	MF_CopyAmxMemory(NULL, NULL, 0);
 	MF_Log("str", "str", 0);
@@ -2752,6 +2697,7 @@ void ValidateMacros_DontCallThis_Smiley() {
 	MF_AmxFindPublic(0, 0, 0);
 	MF_AmxAllot(0, 0, 0, 0);
 	MF_LoadAmxScript(0, 0, 0, 0, 0);
+	MF_LoadAmxScriptEx(0, 0, 0, 0, 0, 0);
 	MF_UnloadAmxScript(0, 0);
 	MF_RegisterSPForward(0, 0, 0, 0, 0, 0);
 	MF_RegisterSPForwardByName(0, 0, 0, 0, 0, 0);
@@ -2770,6 +2716,7 @@ void ValidateMacros_DontCallThis_Smiley() {
 	MF_RemoveLibraries(NULL);
 	MF_OverrideNatives(NULL, NULL);
 	MF_MessageBlock(0, 0, NULL);
+	MF_GetConfigManager();
 }
 #endif
 
@@ -2784,24 +2731,26 @@ void ValidateMacros_DontCallThis_Smiley() {
 #undef realloc
 #undef free
 
-const		unsigned int	m_alloc_unknown = 0;
-const		unsigned int	m_alloc_new = 1;
-const		unsigned int	m_alloc_new_array = 2;
-const		unsigned int	m_alloc_malloc = 3;
-const		unsigned int	m_alloc_calloc = 4;
-const		unsigned int	m_alloc_realloc = 5;
-const		unsigned int	m_alloc_delete = 6;
-const		unsigned int	m_alloc_delete_array = 7;
-const		unsigned int	m_alloc_free = 8;
+const		unsigned int	m_alloc_unknown        = 0;
+const		unsigned int	m_alloc_new            = 1;
+const		unsigned int	m_alloc_new_array      = 2;
+const		unsigned int	m_alloc_malloc         = 3;
+const		unsigned int	m_alloc_calloc         = 4;
+const		unsigned int	m_alloc_realloc        = 5;
+const		unsigned int	m_alloc_delete         = 6;
+const		unsigned int	m_alloc_delete_array   = 7;
+const		unsigned int	m_alloc_free           = 8;
 
 const char *g_Mem_CurrentFilename = "??";
 int g_Mem_CurrentLine = 0;
 const char *g_Mem_CurrentFunc = "??";
 
-const char *Mem_MakeSourceFile(const char *sourceFile) {
+const char *Mem_MakeSourceFile(const char *sourceFile)
+{
 	static char buffer[512];
 	static size_t pos = 0;
-	if (!pos) {
+	if (!pos)
+	{
 		// init
 		buffer[0] = '[';
 		strcpy(buffer + 1, MODULE_NAME);
@@ -2813,7 +2762,8 @@ const char *Mem_MakeSourceFile(const char *sourceFile) {
 	const char *ptr = strrchr(sourceFile, '\\');
 	if (ptr)
 		ptr++;
-	else {
+	else
+	{
 		ptr = strrchr(sourceFile, '/');
 		if (ptr)
 			ptr++;
@@ -2824,19 +2774,22 @@ const char *Mem_MakeSourceFile(const char *sourceFile) {
 	return buffer;
 }
 
-void Mem_SetOwner(const char *filename, int line, const char *function) {
+void Mem_SetOwner(const char *filename, int line, const char *function)
+{
 	g_Mem_CurrentFilename = filename;
 	g_Mem_CurrentLine = line;
 	g_Mem_CurrentFunc = function;
 }
 
-void Mem_ResetGlobals() {
+void Mem_ResetGlobals()
+{
 	Mem_SetOwner("??", 0, "??");
 }
 
 // raw (re/de)allocators
 void *	Mem_Allocator(const char *sourceFile, const unsigned int sourceLine, const char *sourceFunc,
-	const unsigned int allocationType, const size_t reportedSize) {
+			     const unsigned int allocationType, const size_t reportedSize)
+{
 	if (g_fn_Allocator)
 		return g_fn_Allocator(Mem_MakeSourceFile(sourceFile), sourceLine, sourceFunc, allocationType, reportedSize);
 	else
@@ -2844,7 +2797,8 @@ void *	Mem_Allocator(const char *sourceFile, const unsigned int sourceLine, cons
 }
 
 void *	Mem_Reallocator(const char *sourceFile, const unsigned int sourceLine, const char *sourceFunc,
-	const unsigned int reallocationType, const size_t reportedSize, void *reportedAddress) {
+			       const unsigned int reallocationType, const size_t reportedSize, void *reportedAddress)
+{
 	if (g_fn_Reallocator)
 		return g_fn_Reallocator(Mem_MakeSourceFile(sourceFile), sourceLine, sourceFunc, reallocationType, reportedSize, reportedAddress);
 	else
@@ -2852,7 +2806,8 @@ void *	Mem_Reallocator(const char *sourceFile, const unsigned int sourceLine, co
 }
 
 void	Mem_Deallocator(const char *sourceFile, const unsigned int sourceLine, const char *sourceFunc,
-	const unsigned int deallocationType, void *reportedAddress) {
+			      const unsigned int deallocationType, void *reportedAddress)
+{
 	// If you you get user breakpoint here, something failed :)
 	//  - invalid pointer
 	//  - alloc type mismatch	( for example
@@ -2873,17 +2828,18 @@ void	Mem_Deallocator(const char *sourceFile, const unsigned int sourceLine, cons
 void	*operator new(size_t reportedSize)
 {
 	if (reportedSize == 0)
-	reportedSize = 1;
-void *ptr = Mem_Allocator(g_Mem_CurrentFilename, g_Mem_CurrentLine, g_Mem_CurrentFunc, m_alloc_new, reportedSize);
-// :TODO: Handler support ?
-if (ptr)
-return ptr;
+		reportedSize = 1;
+	void *ptr = Mem_Allocator(g_Mem_CurrentFilename, g_Mem_CurrentLine, g_Mem_CurrentFunc, m_alloc_new, reportedSize);
+	// :TODO: Handler support ?
+	if (ptr)
+		return ptr;
 
-// allocation failed
-return NULL;
+	// allocation failed
+	return NULL;
 }
 
-void	*operator new[](size_t reportedSize) {
+void	*operator new[](size_t reportedSize)
+{
 	if (reportedSize == 0)
 		reportedSize = 1;
 	void *ptr = Mem_Allocator(g_Mem_CurrentFilename, g_Mem_CurrentLine, g_Mem_CurrentFunc, m_alloc_new_array, reportedSize);
@@ -2899,16 +2855,17 @@ void	*operator new[](size_t reportedSize) {
 void	*operator new(size_t reportedSize, const char *sourceFile, int sourceLine)
 {
 	if (reportedSize == 0)
-	reportedSize = 1;
-void *ptr = Mem_Allocator(g_Mem_CurrentFilename, g_Mem_CurrentLine, g_Mem_CurrentFunc, m_alloc_new, reportedSize);
-// :TODO: Handler support ?
-if (ptr)
-return ptr;
+		reportedSize = 1;
+	void *ptr = Mem_Allocator(g_Mem_CurrentFilename, g_Mem_CurrentLine, g_Mem_CurrentFunc, m_alloc_new, reportedSize);
+	// :TODO: Handler support ?
+	if (ptr)
+		return ptr;
 
-// allocation failed
-return NULL;
+	// allocation failed
+	return NULL;
 }
-void	*operator new[](size_t reportedSize, const char *sourceFile, int sourceLine) {
+void	*operator new[](size_t reportedSize, const char *sourceFile, int sourceLine)
+{
 	if (reportedSize == 0)
 		reportedSize = 1;
 	void *ptr = Mem_Allocator(g_Mem_CurrentFilename, g_Mem_CurrentLine, g_Mem_CurrentFunc, m_alloc_new_array, reportedSize);
@@ -2920,14 +2877,16 @@ void	*operator new[](size_t reportedSize, const char *sourceFile, int sourceLine
 	return NULL;
 }
 
-void	operator delete(void *reportedAddress) {
+void	operator delete(void *reportedAddress)
+{
 	if (!reportedAddress)
 		return;
 
 	Mem_Deallocator(g_Mem_CurrentFilename, g_Mem_CurrentLine, g_Mem_CurrentFunc, m_alloc_delete, reportedAddress);
 }
 
-void	operator delete[](void *reportedAddress) {
+void	operator delete[](void *reportedAddress)
+{
 	if (!reportedAddress)
 		return;
 
@@ -2937,21 +2896,21 @@ void	operator delete[](void *reportedAddress) {
 #else
 
 #if !defined NO_ALLOC_OVERRIDES && !defined MEMORY_TEST && !defined WIN32
-void * operator new(size_t size){
-	return(calloc(1, size));
+void * operator new(size_t size) {
+	return(calloc(1, size)); 
 }
 
 void * operator new[](size_t size) {
-	return(calloc(1, size));
+	return(calloc(1, size)); 
 }
 
 void operator delete(void * ptr) {
-	if (ptr)
+	if(ptr)
 		free(ptr);
 }
 
 void operator delete[](void * ptr) {
-	if (ptr)
+	if(ptr)
 		free(ptr);
 }
 #endif
@@ -2970,9 +2929,9 @@ void operator delete[](void * ptr) {
 /***
 *
 *	Copyright (c) 1999, 2000 Valve LLC. All rights reserved.
-*
-*	This product contains software technology licensed from Id
-*	Software, Inc. ("Id Technology").  Id Technology (c) 1996 Id Software, Inc.
+*	
+*	This product contains software technology licensed from Id 
+*	Software, Inc. ("Id Technology").  Id Technology (c) 1996 Id Software, Inc. 
 *	All Rights Reserved.
 *
 *   Use, distribution, and modification of this source code and/or resulting
@@ -2985,7 +2944,7 @@ void operator delete[](void * ptr) {
 
 ===== util.cpp ========================================================
 
-Utility code.  Really not optional after all.
+  Utility code.  Really not optional after all.
 
 */
 
@@ -2997,100 +2956,131 @@ Utility code.  Really not optional after all.
 
 #include "osdep.h"			// win32 vsnprintf, etc
 
-char* UTIL_VarArgs(char *format, ...) {
+char* UTIL_VarArgs( char *format, ... )
+{
 	va_list		argptr;
 	static char		string[1024];
-
-	va_start(argptr, format);
-	vsnprintf(string, sizeof(string), format, argptr);
-	va_end(argptr);
+	
+	va_start (argptr, format);
+	vsnprintf (string, sizeof(string), format, argptr);
+	va_end (argptr);
 
 	return string;
 }
-
+	
 
 //=========================================================
 // UTIL_LogPrintf - Prints a logged message to console.
 // Preceded by LOG: ( timestamp ) < message >
 //=========================================================
-void UTIL_LogPrintf(const char *fmt, ...) {
+void UTIL_LogPrintf( const char *fmt, ... )
+{
 	va_list			argptr;
 	static char		string[1024];
-
-	va_start(argptr, fmt);
-	vsnprintf(string, sizeof(string), fmt, argptr);
-	va_end(argptr);
+	
+	va_start ( argptr, fmt );
+	vsnprintf ( string, sizeof(string), fmt, argptr );
+	va_end   ( argptr );
 
 	// Print to server console
-	ALERT(at_logged, "%s", string);
+	ALERT( at_logged, string );
 }
 
 
-void UTIL_HudMessage(CBaseEntity *pEntity, const hudtextparms_t &textparms,
-	const char *pMessage) {
-	if (!pEntity)
+void UTIL_HudMessage(CBaseEntity *pEntity, const hudtextparms_t &textparms, 
+		const char *pMessage)
+{
+	if ( !pEntity )
 		return;
 
-	MESSAGE_BEGIN(MSG_ONE, SVC_TEMPENTITY, NULL, ENT(pEntity->pev));
-	WRITE_BYTE(TE_TEXTMESSAGE);
-	WRITE_BYTE(textparms.channel & 0xFF);
+	MESSAGE_BEGIN( MSG_ONE, SVC_TEMPENTITY, NULL, ENT(pEntity->pev) );
+		WRITE_BYTE( TE_TEXTMESSAGE );
+		WRITE_BYTE( textparms.channel & 0xFF );
 
-	WRITE_SHORT(FixedSigned16(textparms.x, 1 << 13));
-	WRITE_SHORT(FixedSigned16(textparms.y, 1 << 13));
-	WRITE_BYTE(textparms.effect);
+		WRITE_SHORT( FixedSigned16( textparms.x, 1<<13 ) );
+		WRITE_SHORT( FixedSigned16( textparms.y, 1<<13 ) );
+		WRITE_BYTE( textparms.effect );
 
-	WRITE_BYTE(textparms.r1);
-	WRITE_BYTE(textparms.g1);
-	WRITE_BYTE(textparms.b1);
-	WRITE_BYTE(textparms.a1);
+		WRITE_BYTE( textparms.r1 );
+		WRITE_BYTE( textparms.g1 );
+		WRITE_BYTE( textparms.b1 );
+		WRITE_BYTE( textparms.a1 );
 
-	WRITE_BYTE(textparms.r2);
-	WRITE_BYTE(textparms.g2);
-	WRITE_BYTE(textparms.b2);
-	WRITE_BYTE(textparms.a2);
+		WRITE_BYTE( textparms.r2 );
+		WRITE_BYTE( textparms.g2 );
+		WRITE_BYTE( textparms.b2 );
+		WRITE_BYTE( textparms.a2 );
 
-	WRITE_SHORT(FixedUnsigned16(textparms.fadeinTime, 1 << 8));
-	WRITE_SHORT(FixedUnsigned16(textparms.fadeoutTime, 1 << 8));
-	WRITE_SHORT(FixedUnsigned16(textparms.holdTime, 1 << 8));
+		WRITE_SHORT( FixedUnsigned16( textparms.fadeinTime, 1<<8 ) );
+		WRITE_SHORT( FixedUnsigned16( textparms.fadeoutTime, 1<<8 ) );
+		WRITE_SHORT( FixedUnsigned16( textparms.holdTime, 1<<8 ) );
 
-	if (textparms.effect == 2)
-		WRITE_SHORT(FixedUnsigned16(textparms.fxTime, 1 << 8));
-
-	if (strlen(pMessage) < 512) {
-		WRITE_STRING(pMessage);
-	}
-	else {
-		char tmp[512];
-		strncpy(tmp, pMessage, 511);
-		tmp[511] = 0;
-		WRITE_STRING(tmp);
-	}
+		if ( textparms.effect == 2 )
+			WRITE_SHORT( FixedUnsigned16( textparms.fxTime, 1<<8 ) );
+		
+		if ( strlen( pMessage ) < 512 )
+		{
+			WRITE_STRING( pMessage );
+		}
+		else
+		{
+			char tmp[512];
+			strncpy( tmp, pMessage, 511 );
+			tmp[511] = 0;
+			WRITE_STRING( tmp );
+		}
 	MESSAGE_END();
 }
 
-short FixedSigned16(float value, float scale) {
+short FixedSigned16( float value, float scale )
+{
 	int output;
 
-	output = (int)(value * scale);
+	output = (int) (value * scale);
 
-	if (output > 32767)
+	if ( output > 32767 )
 		output = 32767;
 
-	if (output < -32768)
+	if ( output < -32768 )
 		output = -32768;
 
 	return (short)output;
 }
 
-unsigned short FixedUnsigned16(float value, float scale) {
+unsigned short FixedUnsigned16( float value, float scale )
+{
 	int output;
 
-	output = (int)(value * scale);
-	if (output < 0)
+	output = (int) (value * scale);
+	if ( output < 0 )
 		output = 0;
-	if (output > 0xFFFF)
+	if ( output > 0xFFFF )
 		output = 0xFFFF;
 
 	return (unsigned short)output;
 }
 #endif // USE_METAMOD
+
+template unsigned int strncopy<char, char>(char *, const char *src, size_t count);
+template unsigned int strncopy<cell, char>(cell *, const char *src, size_t count);
+template unsigned int strncopy<cell, cell>(cell *, const cell *src, size_t count);
+
+template <typename D, typename S>
+unsigned int strncopy(D *dest, const S *src, size_t count)
+{
+	if (!count)
+	{
+		return 0;
+	}
+
+	D *start = dest;
+
+	while ((*src) && (--count))
+	{
+		*dest++ = *(unsigned char*)src++;
+	}
+
+	*dest = '\0';
+
+	return (dest - start);
+}

--- a/public/amxxsdk/amxxmodule.h
+++ b/public/amxxsdk/amxxmodule.h
@@ -1,7 +1,16 @@
-/*
-* AMX Mod X Module Interface Functions
-* This file may be freely used
-*/
+// vim: set ts=4 sw=4 tw=99 noet:
+//
+// AMX Mod X, based on AMX Mod by Aleksander Naszko ("OLO").
+// Copyright (C) The AMX Mod X Development Team.
+//
+// This software is licensed under the GNU General Public License, version 3 or higher.
+// Additional exceptions apply. For full license details, see LICENSE.txt or visit:
+//     https://alliedmods.net/amxmodx-license
+//
+
+//
+// Module SDK
+//
 
 // prevent double include
 #ifndef __AMXXMODULE_H__
@@ -9,6 +18,7 @@
 
 // config
 #include "moduleconfig.h"
+#include <IGameConfigs.h>
 
 #include <stddef.h> // size_t
 // metamod include files
@@ -44,7 +54,8 @@
 #define AMXX_INTERFACE_VERSION 4
 
 // amxx module info
-struct amxx_module_info_s {
+struct amxx_module_info_s
+{
 	const char *name;
 	const char *author;
 	const char *version;
@@ -68,352 +79,352 @@ struct amxx_module_info_s {
 // Copyright (c) ITB CompuPhase, 1997-2005
 
 #if defined HAVE_STDINT_H
-#include <stdint.h>
+  #include <stdint.h>
 #else
-#if defined __LCC__ || defined __DMC__ || defined LINUX || defined __APPLE__
-#if defined HAVE_INTTYPES_H
-#include <inttypes.h>
-#else
-#include <stdint.h>
-#endif
-#elif !defined __STDC_VERSION__ || __STDC_VERSION__ < 199901L
-/* The ISO C99 defines the int16_t and int_32t types. If the compiler got
-* here, these types are probably undefined.
-*/
-#if defined __MACH__
-#include <ppc/types.h>
-typedef unsigned short int  uint16_t;
-typedef unsigned long int   uint32_t;
-#elif defined __FreeBSD__
-#include <inttypes.h>
-#else
-typedef short int           int16_t;
-typedef unsigned short int  uint16_t;
-#if defined SN_TARGET_PS2
-typedef int               int32_t;
-typedef unsigned int      uint32_t;
-#else
-typedef long int          int32_t;
-typedef unsigned long int uint32_t;
-#endif
-#if defined __WIN32__ || defined _WIN32 || defined WIN32
-typedef __int64	          int64_t;
-typedef unsigned __int64  uint64_t;
-#define HAVE_I64
-#elif defined __GNUC__
-typedef long long         int64_t;
-typedef unsigned long long uint64_t;
-#define HAVE_I64
-#endif
-#endif
-#endif
-#define HAVE_STDINT_H
+  #if defined __LCC__ || defined __DMC__ || defined LINUX || defined __APPLE__
+    #if defined HAVE_INTTYPES_H
+      #include <inttypes.h>
+    #else
+      #include <stdint.h>
+    #endif
+  #elif !defined __STDC_VERSION__ || __STDC_VERSION__ < 199901L
+    /* The ISO C99 defines the int16_t and int_32t types. If the compiler got
+     * here, these types are probably undefined.
+     */
+    #if defined __MACH__
+      #include <ppc/types.h>
+      typedef unsigned short int  uint16_t;
+      typedef unsigned long int   uint32_t;
+    #elif defined __FreeBSD__
+      #include <inttypes.h>
+    #else
+      typedef short int           int16_t;
+      typedef unsigned short int  uint16_t;
+      #if defined SN_TARGET_PS2
+        typedef int               int32_t;
+        typedef unsigned int      uint32_t;
+      #else
+        typedef long int          int32_t;
+        typedef unsigned long int uint32_t;
+      #endif
+      #if defined __WIN32__ || defined _WIN32 || defined WIN32
+        typedef __int64	          int64_t;
+        typedef unsigned __int64  uint64_t;
+        #define HAVE_I64
+      #elif defined __GNUC__
+        typedef long long         int64_t;
+        typedef unsigned long long uint64_t;
+        #define HAVE_I64
+      #endif
+    #endif
+  #endif
+  #define HAVE_STDINT_H
 #endif
 #if defined _LP64 || defined WIN64 || defined _WIN64
-#if !defined __64BIT__
-#define __64BIT__
-#endif
+  #if !defined __64BIT__
+    #define __64BIT__
+  #endif
 #endif
 
 /* calling convention for native functions */
 #if !defined AMX_NATIVE_CALL
-#define AMX_NATIVE_CALL
+  #define AMX_NATIVE_CALL
 #endif
 /* calling convention for all interface functions and callback functions */
 #if !defined AMXAPI
-#if defined STDECL
-#define AMXAPI      __stdcall
-#elif defined CDECL
-#define AMXAPI      __cdecl
-#else
-#define AMXAPI
-#endif
+  #if defined STDECL
+    #define AMXAPI      __stdcall
+  #elif defined CDECL
+    #define AMXAPI      __cdecl
+  #else
+    #define AMXAPI
+  #endif
 #endif
 #if !defined AMXEXPORT
-#define AMXEXPORT
+  #define AMXEXPORT
 #endif
 
 #if !defined PAWN_CELL_SIZE
-#define PAWN_CELL_SIZE 32     /* by default, use 32-bit cells */
+  #define PAWN_CELL_SIZE 32     /* by default, use 32-bit cells */
 #endif
 #if PAWN_CELL_SIZE==16
-typedef uint16_t  ucell;
-typedef int16_t   cell;
+  typedef uint16_t  ucell;
+  typedef int16_t   cell;
 #elif PAWN_CELL_SIZE==32
-typedef uint32_t  ucell;
-typedef int32_t   cell;
+  typedef uint32_t  ucell;
+  typedef int32_t   cell;
 #define REAL	float
 #elif PAWN_CELL_SIZE==64
-typedef uint64_t  ucell;
-typedef int64_t   cell;
+  typedef uint64_t  ucell;
+  typedef int64_t   cell;
 #define REAL	double
 #else
-#error Unsupported cell size (PAWN_CELL_SIZE)
+  #error Unsupported cell size (PAWN_CELL_SIZE)
 #endif
 
 #define UNPACKEDMAX   ((1 << (sizeof(cell)-1)*8) - 1)
 #define UNLIMITED     (~1u >> 1)
 
 struct tagAMX;
-typedef cell(AMX_NATIVE_CALL *AMX_NATIVE)(struct tagAMX *amx, cell *params);
+typedef cell (AMX_NATIVE_CALL *AMX_NATIVE)(struct tagAMX *amx, cell *params);
 typedef int (AMXAPI *AMX_CALLBACK)(struct tagAMX *amx, cell index,
-	cell *result, cell *params);
+                                   cell *result, cell *params);
 typedef int (AMXAPI *AMX_DEBUG)(struct tagAMX *amx);
 #if !defined _FAR
-#define _FAR
+  #define _FAR
 #endif
 
 #if defined _MSC_VER
-#pragma warning(disable:4103)  /* disable warning message 4103 that complains
-* about pragma pack in a header file */
-#pragma warning(disable:4100)  /* "'%$S' : unreferenced formal parameter" */
+	#pragma warning(disable:4103)  /* disable warning message 4103 that complains
+	                                * about pragma pack in a header file */
+	#pragma warning(disable:4100)  /* "'%$S' : unreferenced formal parameter" */
 
-#if _MSC_VER >= 1400
-#if !defined NO_MSVC8_AUTO_COMPAT
+	#if _MSC_VER >= 1400
+		#if !defined NO_MSVC8_AUTO_COMPAT
 
-/* Disable deprecation warnings concerning unsafe CRT functions */
-#if !defined _CRT_SECURE_NO_DEPRECATE
-#define _CRT_SECURE_NO_DEPRECATE
-#endif
+			/* Disable deprecation warnings concerning unsafe CRT functions */
+			#if !defined _CRT_SECURE_NO_DEPRECATE
+				#define _CRT_SECURE_NO_DEPRECATE
+			#endif
 
-/* Replace the POSIX function with ISO C++ conformant ones as they are now deprecated */
-#define access _access
-#define cabs _cabs
-#define cgets _cgets
-#define chdir _chdir
-#define chmod _chmod
-#define chsize _chsize
-#define close _close
-#define cprintf _cprintf
-#define cputs _cputts
-#define creat _creat
-#define cscanf _cscanf
-#define cwait _cwait
-#define dup _dup
-#define dup2 _dup2
-#define ecvt _ecvt
-#define eof _eof
-#define execl _execl
-#define execle _execle
-#define execlp _execlp
-#define execlpe _execlpe
-#define execv _execv
-#define execve _execv
-#define execvp _execvp
-#define execvpe _execvpe
-#define fcloseall _fcloseall
-#define fcvt _fcvt
-#define fdopen _fdopen
-#define fgetchar _fgetchar
-#define filelength _filelength
-#define fileno _fileno
-#define flushall _flushall
-#define fputchar _fputchar
-#define gcvt _gcvt
-#define getch _getch
-#define getche _getche
-#define getcwd _getcwd
-#define getpid _getpid
-#define getw _getw
-#define hypot _hypot
-#define inp _inp
-#define inpw _inpw
-#define isascii __isascii
-#define isatty _isatty
-#define iscsym __iscsym
-#define iscsymf __iscsymf
-#define itoa _itoa
-#define j0 _j0
-#define j1 _j1
-#define jn _jn
-#define kbhit _kbhit
-#define lfind _lfind
-#define locking _locking
-#define lsearch _lsearch
-#define lseek _lseek
-#define ltoa _ltoa
-#define memccpy _memccpy
-#define memicmp _memicmp
-#define mkdir _mkdir
-#define mktemp _mktemp
-#define open _open
-#define outp _outp
-#define outpw _outpw
-#define putch _putch
-#define putenv _putenv
-#define putw _putw
-#define read _read
-#define rmdir _rmdir
-#define rmtmp _rmtmp
-#define setmode _setmode
-#define sopen _sopen
-#define spawnl _spawnl
-#define spawnle _spawnle
-#define spawnlp _spawnlp
-#define spawnlpe _spawnlpe
-#define spawnv _spawnv
-#define spawnve _spawnve
-#define spawnvp _spawnvp
-#define spawnvpe _spawnvpe
-#define strcmpi _strcmpi
-#define strdup _strdup
-#define stricmp _stricmp
-#define strlwr _strlwr
-#define strnicmp _strnicmp
-#define strnset _strnset
-#define strrev _strrev
-#define strset _strset
-#define strupr _strupr
-#define swab _swab
-#define tell _tell
-#define tempnam _tempnam
-#define toascii __toascii
-#define tzset _tzset
-#define ultoa _ultoa
-#define umask _umask
-#define ungetch _ungetch
-#define unlink _unlink
-#define wcsdup _wcsdup
-#define wcsicmp _wcsicmp
-#define wcsicoll _wcsicoll
-#define wcslwr _wcslwr
-#define wcsnicmp _wcsnicmp
-#define wcsnset _wcsnset
-#define wcsrev _wcsrev
-#define wcsset _wcsset
-#define wcsupr _wcsupr
-#define write _write
-#define y0 _y0
-#define y1 _y1
-#define yn _yn
+			/* Replace the POSIX function with ISO C++ conformant ones as they are now deprecated */
+			#define access _access
+			#define cabs _cabs
+			#define cgets _cgets
+			#define chdir _chdir
+			#define chmod _chmod
+			#define chsize _chsize
+			#define close _close
+			#define cprintf _cprintf
+			#define cputs _cputts
+			#define creat _creat
+			#define cscanf _cscanf
+			#define cwait _cwait
+			#define dup _dup
+			#define dup2 _dup2
+			#define ecvt _ecvt
+			#define eof _eof
+			#define execl _execl
+			#define execle _execle
+			#define execlp _execlp
+			#define execlpe _execlpe
+			#define execv _execv
+			#define execve _execv
+			#define execvp _execvp
+			#define execvpe _execvpe
+			#define fcloseall _fcloseall
+			#define fcvt _fcvt
+			#define fdopen _fdopen
+			#define fgetchar _fgetchar
+			#define filelength _filelength
+			#define fileno _fileno
+			#define flushall _flushall
+			#define fputchar _fputchar
+			#define gcvt _gcvt
+			#define getch _getch
+			#define getche _getche
+			#define getcwd _getcwd
+			#define getpid _getpid
+			#define getw _getw
+			#define hypot _hypot
+			#define inp _inp
+			#define inpw _inpw
+			#define isascii __isascii
+			#define isatty _isatty
+			#define iscsym __iscsym
+			#define iscsymf __iscsymf
+			#define itoa _itoa
+			#define j0 _j0
+			#define j1 _j1
+			#define jn _jn
+			#define kbhit _kbhit
+			#define lfind _lfind
+			#define locking _locking
+			#define lsearch _lsearch
+			#define lseek _lseek
+			#define ltoa _ltoa
+			#define memccpy _memccpy
+			#define memicmp _memicmp
+			#define mkdir _mkdir
+			#define mktemp _mktemp
+			#define open _open
+			#define outp _outp
+			#define outpw _outpw
+			#define putch _putch
+			#define putenv _putenv
+			#define putw _putw
+			#define read _read
+			#define rmdir _rmdir
+			#define rmtmp _rmtmp
+			#define setmode _setmode
+			#define sopen _sopen
+			#define spawnl _spawnl
+			#define spawnle _spawnle
+			#define spawnlp _spawnlp
+			#define spawnlpe _spawnlpe
+			#define spawnv _spawnv
+			#define spawnve _spawnve
+			#define spawnvp _spawnvp
+			#define spawnvpe _spawnvpe
+			#define strcmpi _strcmpi
+			#define strdup _strdup
+			#define stricmp _stricmp
+			#define strlwr _strlwr
+			#define strnicmp _strnicmp
+			#define strnset _strnset
+			#define strrev _strrev
+			#define strset _strset
+			#define strupr _strupr
+			#define swab _swab
+			#define tell _tell
+			#define tempnam _tempnam
+			#define toascii __toascii
+			#define tzset _tzset
+			#define ultoa _ultoa
+			#define umask _umask
+			#define ungetch _ungetch
+			#define unlink _unlink
+			#define wcsdup _wcsdup
+			#define wcsicmp _wcsicmp
+			#define wcsicoll _wcsicoll
+			#define wcslwr _wcslwr
+			#define wcsnicmp _wcsnicmp
+			#define wcsnset _wcsnset
+			#define wcsrev _wcsrev
+			#define wcsset _wcsset
+			#define wcsupr _wcsupr
+			#define write _write
+			#define y0 _y0
+			#define y1 _y1
+			#define yn _yn
 
-/* Disable deprecation warnings because MSVC8 seemingly thinks the ISO C++ conformant
-* functions above are deprecated. */
-#pragma warning (disable:4996)
-
-#endif
-#else
-#define vsnprintf _vsnprintf
-#endif
+			/* Disable deprecation warnings because MSVC8 seemingly thinks the ISO C++ conformant 
+			 * functions above are deprecated. */
+			#pragma warning (disable:4996)
+				
+		#endif
+	#else
+		#define vsnprintf _vsnprintf
+	#endif
 #endif
 
 
 /* Some compilers do not support the #pragma align, which should be fine. Some
-* compilers give a warning on unknown #pragmas, which is not so fine...
-*/
+ * compilers give a warning on unknown #pragmas, which is not so fine...
+ */
 #if (defined SN_TARGET_PS2 || defined __GNUC__) && !defined AMX_NO_ALIGN
-#define AMX_NO_ALIGN
+  #define AMX_NO_ALIGN
 #endif
 
 #if defined __GNUC__
-#define PACKED        __attribute__((packed))
+  #define PACKED        __attribute__((packed))
 #else
-#define PACKED
+  #define PACKED
 #endif
 
 #if !defined AMX_NO_ALIGN
-#if defined LINUX || defined __FreeBSD__ || defined __APPLE__
-#pragma pack(1)         /* structures must be packed (byte-aligned) */
-#elif defined MACOS && defined __MWERKS__
-#pragma options align=mac68k
-#else
-#pragma pack(push)
-#pragma pack(1)         /* structures must be packed (byte-aligned) */
-#if defined __TURBOC__
-#pragma option -a-    /* "pack" pragma for older Borland compilers */
-#endif
-#endif
+  #if defined LINUX || defined __FreeBSD__ || defined __APPLE__
+    #pragma pack(1)         /* structures must be packed (byte-aligned) */
+  #elif defined MACOS && defined __MWERKS__
+	#pragma options align=mac68k
+  #else
+    #pragma pack(push)
+    #pragma pack(1)         /* structures must be packed (byte-aligned) */
+    #if defined __TURBOC__
+      #pragma option -a-    /* "pack" pragma for older Borland compilers */
+    #endif
+  #endif
 #endif
 
 typedef struct {
-	const char _FAR *name PACKED;
-	AMX_NATIVE func       PACKED;
+  const char _FAR *name PACKED;
+  AMX_NATIVE func       PACKED;
 } AMX_NATIVE_INFO;
 
 #define AMX_USERNUM     4
 
 /* The AMX structure is the internal structure for many functions. Not all
-* fields are valid at all times; many fields are cached in local variables.
-*/
+ * fields are valid at all times; many fields are cached in local variables.
+ */
 typedef struct tagAMX {
-	unsigned char _FAR *base PACKED; /* points to the AMX header plus the code, optionally also the data */
-	unsigned char _FAR *data PACKED; /* points to separate data+stack+heap, may be NULL */
-	AMX_CALLBACK callback PACKED;
-	AMX_DEBUG debug       PACKED; /* debug callback */
-								  /* for external functions a few registers must be accessible from the outside */
-	cell cip              PACKED; /* instruction pointer: relative to base + amxhdr->cod */
-	cell frm              PACKED; /* stack frame base: relative to base + amxhdr->dat */
-	cell hea              PACKED; /* top of the heap: relative to base + amxhdr->dat */
-	cell hlw              PACKED; /* bottom of the heap: relative to base + amxhdr->dat */
-	cell stk              PACKED; /* stack pointer: relative to base + amxhdr->dat */
-	cell stp              PACKED; /* top of the stack: relative to base + amxhdr->dat */
-	int flags             PACKED; /* current status, see amx_Flags() */
-								  /* user data */
-	long usertags[AMX_USERNUM] PACKED;
-	//okay userdata[3] in AMX Mod X is for the CPlugin * pointer
-	//we're also gonna set userdata[2] to a special debug structure
-	void _FAR *userdata[AMX_USERNUM] PACKED;
-	/* native functions can raise an error */
-	int error             PACKED;
-	/* passing parameters requires a "count" field */
-	int paramcount;
-	/* the sleep opcode needs to store the full AMX status */
-	cell pri              PACKED;
-	cell alt              PACKED;
-	cell reset_stk        PACKED;
-	cell reset_hea        PACKED;
-	cell sysreq_d         PACKED; /* relocated address/value for the SYSREQ.D opcode */
-								  /* support variables for the JIT */
-	int reloc_size      PACKED; /* required temporary buffer for relocations */
-	long code_size      PACKED; /* estimated memory footprint of the native code */
+  unsigned char _FAR *base PACKED; /* points to the AMX header plus the code, optionally also the data */
+  unsigned char _FAR *data PACKED; /* points to separate data+stack+heap, may be NULL */
+  AMX_CALLBACK callback PACKED;
+  AMX_DEBUG debug       PACKED; /* debug callback */
+  /* for external functions a few registers must be accessible from the outside */
+  cell cip              PACKED; /* instruction pointer: relative to base + amxhdr->cod */
+  cell frm              PACKED; /* stack frame base: relative to base + amxhdr->dat */
+  cell hea              PACKED; /* top of the heap: relative to base + amxhdr->dat */
+  cell hlw              PACKED; /* bottom of the heap: relative to base + amxhdr->dat */
+  cell stk              PACKED; /* stack pointer: relative to base + amxhdr->dat */
+  cell stp              PACKED; /* top of the stack: relative to base + amxhdr->dat */
+  int flags             PACKED; /* current status, see amx_Flags() */
+  /* user data */
+  long usertags[AMX_USERNUM] PACKED;
+  //okay userdata[3] in AMX Mod X is for the CPlugin * pointer
+  //we're also gonna set userdata[2] to a special debug structure
+  void _FAR *userdata[AMX_USERNUM] PACKED;
+  /* native functions can raise an error */
+  int error             PACKED;
+  /* passing parameters requires a "count" field */
+  int paramcount;
+  /* the sleep opcode needs to store the full AMX status */
+  cell pri              PACKED;
+  cell alt              PACKED;
+  cell reset_stk        PACKED;
+  cell reset_hea        PACKED;
+  cell sysreq_d         PACKED; /* relocated address/value for the SYSREQ.D opcode */
+  /* support variables for the JIT */
+  int reloc_size      PACKED; /* required temporary buffer for relocations */
+  long code_size      PACKED; /* estimated memory footprint of the native code */
 } PACKED AMX;
 
 enum {
-	AMX_ERR_NONE,
-	/* reserve the first 15 error codes for exit codes of the abstract machine */
-	AMX_ERR_EXIT,         /* forced exit */
-	AMX_ERR_ASSERT,       /* assertion failed */
-	AMX_ERR_STACKERR,     /* stack/heap collision */
-	AMX_ERR_BOUNDS,       /* index out of bounds */
-	AMX_ERR_MEMACCESS,    /* invalid memory access */
-	AMX_ERR_INVINSTR,     /* invalid instruction */
-	AMX_ERR_STACKLOW,     /* stack underflow */
-	AMX_ERR_HEAPLOW,      /* heap underflow */
-	AMX_ERR_CALLBACK,     /* no callback, or invalid callback */
-	AMX_ERR_NATIVE,       /* native function failed */
-	AMX_ERR_DIVIDE,       /* divide by zero */
-	AMX_ERR_SLEEP,        /* go into sleepmode - code can be restarted */
-	AMX_ERR_INVSTATE,     /* invalid state for this access */
+  AMX_ERR_NONE,
+  /* reserve the first 15 error codes for exit codes of the abstract machine */
+  AMX_ERR_EXIT,         /* forced exit */
+  AMX_ERR_ASSERT,       /* assertion failed */
+  AMX_ERR_STACKERR,     /* stack/heap collision */
+  AMX_ERR_BOUNDS,       /* index out of bounds */
+  AMX_ERR_MEMACCESS,    /* invalid memory access */
+  AMX_ERR_INVINSTR,     /* invalid instruction */
+  AMX_ERR_STACKLOW,     /* stack underflow */
+  AMX_ERR_HEAPLOW,      /* heap underflow */
+  AMX_ERR_CALLBACK,     /* no callback, or invalid callback */
+  AMX_ERR_NATIVE,       /* native function failed */
+  AMX_ERR_DIVIDE,       /* divide by zero */
+  AMX_ERR_SLEEP,        /* go into sleepmode - code can be restarted */
+  AMX_ERR_INVSTATE,     /* invalid state for this access */
 
-	AMX_ERR_MEMORY = 16,  /* out of memory */
-	AMX_ERR_FORMAT,       /* invalid file format */
-	AMX_ERR_VERSION,      /* file is for a newer version of the AMX */
-	AMX_ERR_NOTFOUND,     /* function not found */
-	AMX_ERR_INDEX,        /* invalid index parameter (bad entry point) */
-	AMX_ERR_DEBUG,        /* debugger cannot run */
-	AMX_ERR_INIT,         /* AMX not initialized (or doubly initialized) */
-	AMX_ERR_USERDATA,     /* unable to set user data field (table full) */
-	AMX_ERR_INIT_JIT,     /* cannot initialize the JIT */
-	AMX_ERR_PARAMS,       /* parameter error */
-	AMX_ERR_DOMAIN,       /* domain error, expression result does not fit in range */
+  AMX_ERR_MEMORY = 16,  /* out of memory */
+  AMX_ERR_FORMAT,       /* invalid file format */
+  AMX_ERR_VERSION,      /* file is for a newer version of the AMX */
+  AMX_ERR_NOTFOUND,     /* function not found */
+  AMX_ERR_INDEX,        /* invalid index parameter (bad entry point) */
+  AMX_ERR_DEBUG,        /* debugger cannot run */
+  AMX_ERR_INIT,         /* AMX not initialized (or doubly initialized) */
+  AMX_ERR_USERDATA,     /* unable to set user data field (table full) */
+  AMX_ERR_INIT_JIT,     /* cannot initialize the JIT */
+  AMX_ERR_PARAMS,       /* parameter error */
+  AMX_ERR_DOMAIN,       /* domain error, expression result does not fit in range */
 };
 
 #if !defined AMX_NO_ALIGN
-#if defined(__linux__) || defined(__APPLE__)
-#pragma pack()    /* reset default packing */
-#else
-#pragma pack(pop) /* reset previous packing */
-#endif
+  #if defined(__linux__) || defined(__APPLE__)
+    #pragma pack()    /* reset default packing */
+  #else
+    #pragma pack(pop) /* reset previous packing */
+  #endif
 #endif
 
 
 // ***** declare functions *****
 
 #ifdef USE_METAMOD
-void UTIL_LogPrintf(const char *fmt, ...);
+void UTIL_LogPrintf( const char *fmt, ... );
 void UTIL_HudMessage(CBaseEntity *pEntity, const hudtextparms_t &textparms, const char *pMessage);
-short FixedSigned16(float value, float scale);
-unsigned short FixedUnsigned16(float value, float scale);
+short FixedSigned16( float value, float scale );
+unsigned short FixedUnsigned16( float value, float scale );
 
 #ifdef FN_META_QUERY
 void FN_META_QUERY(void);
@@ -492,7 +503,7 @@ void FN_ResetGlobalState(void);
 #endif // FN_ResetGlobalState
 
 #ifdef FN_ClientConnect
-BOOL FN_ClientConnect(edict_t *pEntity, const char *pszName, const char *pszAddress, char szRejectReason[128]);
+BOOL FN_ClientConnect(edict_t *pEntity, const char *pszName, const char *pszAddress, char szRejectReason[ 128 ]);
 #endif // FN_ClientConnect
 
 #ifdef FN_ClientDisconnect
@@ -695,7 +706,7 @@ void FN_ResetGlobalState_Post(void);
 #endif // FN_ResetGlobalState_Post
 
 #ifdef FN_ClientConnect_Post
-BOOL FN_ClientConnect_Post(edict_t *pEntity, const char *pszName, const char *pszAddress, char szRejectReason[128]);
+BOOL FN_ClientConnect_Post(edict_t *pEntity, const char *pszName, const char *pszAddress, char szRejectReason[ 128 ]);
 #endif // FN_ClientConnect_Post
 
 #ifdef FN_ClientDisconnect_Post
@@ -981,7 +992,7 @@ void FN_TraceModel(const float *v1, const float *v2, int hullNumber, edict_t *pe
 #endif // FN_TraceModel
 
 #ifdef FN_TraceTexture
-const char *FN_TraceTexture(edict_t *pTextureEntity, const float *v1, const float *v2);
+const char *FN_TraceTexture(edict_t *pTextureEntity, const float *v1, const float *v2 );
 #endif // FN_TraceTexture
 
 #ifdef FN_TraceSphere
@@ -1009,7 +1020,7 @@ void FN_ParticleEffect(const float *org, const float *dir, float color, float co
 #endif // FN_ParticleEffect
 
 #ifdef FN_LightStyle
-void FN_LightStyle(int style, char *val);
+void FN_LightStyle(int style, const char *val);
 #endif // FN_LightStyle
 
 #ifdef FN_DecalIndex
@@ -1177,7 +1188,7 @@ int FN_Cmd_Argc(void);
 #endif // FN_Cmd_Argc
 
 #ifdef FN_GetAttachment
-void FN_GetAttachment(const edict_t *pEdict, int iAttachment, float *rgflOrigin, float *rgflAngles);
+void FN_GetAttachment(const edict_t *pEdict, int iAttachment, float *rgflOrigin, float *rgflAngles );
 #endif // FN_GetAttachment
 
 #ifdef FN_CRC32_Init
@@ -1217,7 +1228,7 @@ void FN_CrosshairAngle(const edict_t *pClient, float pitch, float yaw);
 #endif // FN_CrosshairAngle
 
 #ifdef FN_LoadFileForMe
-byte *FN_LoadFileForMe(char *filename, int *pLength);
+byte *FN_LoadFileForMe(const char *filename, int *pLength);
 #endif // FN_LoadFileForMe
 
 #ifdef FN_FreeFile
@@ -1289,7 +1300,7 @@ int FN_PrecacheGeneric(const char *s);
 #endif // FN_PrecacheGeneric
 
 #ifdef FN_GetPlayerUserId
-int FN_GetPlayerUserId(edict_t *e);
+int FN_GetPlayerUserId(edict_t *e );
 #endif // FN_GetPlayerUserId
 
 #ifdef FN_BuildSoundMsg
@@ -1309,7 +1320,7 @@ unsigned int FN_GetPlayerWONId(edict_t *e);
 #endif // FN_GetPlayerWONId
 
 #ifdef FN_Info_RemoveKey
-void FN_Info_RemoveKey(char *s, const char *key);
+void FN_Info_RemoveKey( char *s, const char *key);
 #endif // FN_Info_RemoveKey
 
 #ifdef FN_GetPhysicsKeyValue
@@ -1321,7 +1332,7 @@ void FN_SetPhysicsKeyValue(const edict_t *pClient, const char *key, const char *
 #endif // FN_SetPhysicsKeyValue
 
 #ifdef FN_GetPhysicsInfoString
-const char *FN_GetPhysicsInfoString(const edict_t *pClient);
+const char *FN_GetPhysicsInfoString( const edict_t *pClient);
 #endif // FN_GetPhysicsInfoString
 
 #ifdef FN_PrecacheEvent
@@ -1353,7 +1364,7 @@ void FN_DeltaUnsetField(struct delta_s *pFields, const char *fieldname);
 #endif // FN_DeltaUnsetField
 
 #ifdef FN_DeltaAddEncoder
-void FN_DeltaAddEncoder(char *name, void(*conditionalencode)(struct delta_s *pFields, const unsigned char *from, const unsigned char *to));
+void FN_DeltaAddEncoder(const char *name, void (*conditionalencode)( struct delta_s *pFields, const unsigned char *from, const unsigned char *to ) );
 #endif // FN_DeltaAddEncoder
 
 #ifdef FN_GetCurrentPlayer
@@ -1385,7 +1396,7 @@ int FN_engCreateInstancedBaseline(int classname, struct entity_state_s *baseline
 #endif // FN_engCreateInstancedBaseline
 
 #ifdef FN_Cvar_DirectSet
-void FN_Cvar_DirectSet(struct cvar_s *var, char *value);
+void FN_Cvar_DirectSet(struct cvar_s *var, const char *value);
 #endif // FN_Cvar_DirectSet
 
 #ifdef FN_ForceUnmodified
@@ -1397,7 +1408,7 @@ void FN_GetPlayerStats(const edict_t *pClient, int *ping, int *packet_loss);
 #endif // FN_GetPlayerStats
 
 #ifdef FN_AddServerCommand
-void FN_AddServerCommand(char *cmd_name, void(*function) (void));
+void FN_AddServerCommand(char *cmd_name, void (*function) (void));
 #endif // FN_AddServerCommand
 
 #ifdef FN_Voice_GetClientListening
@@ -1562,7 +1573,7 @@ void FN_TraceModel_Post(const float *v1, const float *v2, int hullNumber, edict_
 #endif // FN_TraceModel_Post
 
 #ifdef FN_TraceTexture_Post
-const char *FN_TraceTexture_Post(edict_t *pTextureEntity, const float *v1, const float *v2);
+const char *FN_TraceTexture_Post(edict_t *pTextureEntity, const float *v1, const float *v2 );
 #endif // FN_TraceTexture_Post
 
 #ifdef FN_TraceSphere_Post
@@ -1590,7 +1601,7 @@ void FN_ParticleEffect_Post(const float *org, const float *dir, float color, flo
 #endif // FN_ParticleEffect_Post
 
 #ifdef FN_LightStyle_Post
-void FN_LightStyle_Post(int style, char *val);
+void FN_LightStyle_Post(int style, const char *val);
 #endif // FN_LightStyle_Post
 
 #ifdef FN_DecalIndex_Post
@@ -1758,7 +1769,7 @@ int FN_Cmd_Argc_Post(void);
 #endif // FN_Cmd_Argc_Post
 
 #ifdef FN_GetAttachment_Post
-void FN_GetAttachment_Post(const edict_t *pEdict, int iAttachment, float *rgflOrigin, float *rgflAngles);
+void FN_GetAttachment_Post(const edict_t *pEdict, int iAttachment, float *rgflOrigin, float *rgflAngles );
 #endif // FN_GetAttachment_Post
 
 #ifdef FN_CRC32_Init_Post
@@ -1798,7 +1809,7 @@ void FN_CrosshairAngle_Post(const edict_t *pClient, float pitch, float yaw);
 #endif // FN_CrosshairAngle_Post
 
 #ifdef FN_LoadFileForMe_Post
-byte *FN_LoadFileForMe_Post(char *filename, int *pLength);
+byte *FN_LoadFileForMe_Post(const char *filename, int *pLength);
 #endif // FN_LoadFileForMe_Post
 
 #ifdef FN_FreeFile_Post
@@ -1870,7 +1881,7 @@ int FN_PrecacheGeneric_Post(const char *s);
 #endif // FN_PrecacheGeneric_Post
 
 #ifdef FN_GetPlayerUserId_Post
-int FN_GetPlayerUserId_Post(edict_t *e);
+int FN_GetPlayerUserId_Post(edict_t *e );
 #endif // FN_GetPlayerUserId_Post
 
 #ifdef FN_BuildSoundMsg_Post
@@ -1890,7 +1901,7 @@ unsigned int FN_GetPlayerWONId_Post(edict_t *e);
 #endif // FN_GetPlayerWONId_Post
 
 #ifdef FN_Info_RemoveKey_Post
-void FN_Info_RemoveKey_Post(char *s, const char *key);
+void FN_Info_RemoveKey_Post( char *s, const char *key);
 #endif // FN_Info_RemoveKey_Post
 
 #ifdef FN_GetPhysicsKeyValue_Post
@@ -1902,7 +1913,7 @@ void FN_SetPhysicsKeyValue_Post(const edict_t *pClient, const char *key, const c
 #endif // FN_SetPhysicsKeyValue_Post
 
 #ifdef FN_GetPhysicsInfoString_Post
-const char *FN_GetPhysicsInfoString_Post(const edict_t *pClient);
+const char *FN_GetPhysicsInfoString_Post( const edict_t *pClient);
 #endif // FN_GetPhysicsInfoString_Post
 
 #ifdef FN_PrecacheEvent_Post
@@ -1934,7 +1945,7 @@ void FN_DeltaUnsetField_Post(struct delta_s *pFields, const char *fieldname);
 #endif // FN_DeltaUnsetField_Post
 
 #ifdef FN_DeltaAddEncoder_Post
-void FN_DeltaAddEncoder_Post(char *name, void(*conditionalencode)(struct delta_s *pFields, const unsigned char *from, const unsigned char *to));
+void FN_DeltaAddEncoder_Post(const char *name, void (*conditionalencode)( struct delta_s *pFields, const unsigned char *from, const unsigned char *to ) );
 #endif // FN_DeltaAddEncoder_Post
 
 #ifdef FN_GetCurrentPlayer_Post
@@ -1966,7 +1977,7 @@ int FN_engCreateInstancedBaseline_Post(int classname, struct entity_state_s *bas
 #endif // FN_engCreateInstancedBaseline_Post
 
 #ifdef FN_Cvar_DirectSet_Post
-void FN_Cvar_DirectSet_Post(struct cvar_s *var, char *value);
+void FN_Cvar_DirectSet_Post(struct cvar_s *var, const char *value);
 #endif // FN_Cvar_DirectSet_Post
 
 #ifdef FN_ForceUnmodified_Post
@@ -1978,7 +1989,7 @@ void FN_GetPlayerStats_Post(const edict_t *pClient, int *ping, int *packet_loss)
 #endif // FN_GetPlayerStats_Post
 
 #ifdef FN_AddServerCommand_Post
-void FN_AddServerCommand_Post(char *cmd_name, void(*function)(void));
+void FN_AddServerCommand_Post(char *cmd_name, void (*function)(void));
 #endif // FN_AddServerCommand_Post
 
 #ifdef FN_Voice_GetClientListening_Post
@@ -2059,14 +2070,16 @@ void FN_AMXX_PLUGINSUNLOADED(void);
 typedef void* (*PFN_REQ_FNPTR)(const char * /*name*/);
 
 // ***** Module funcs stuff *****
-enum ForwardExecType {
+enum ForwardExecType
+{
 	ET_IGNORE = 0,					// Ignore return vaue
 	ET_STOP,						// Stop on PLUGIN_HANDLED
 	ET_STOP2,						// Stop on PLUGIN_HANDLED, continue on other values, return biggest return value
 	ET_CONTINUE,					// Continue; return biggest return value
 };
 
-enum ForwardParam {
+enum ForwardParam
+{
 	FP_DONE = -1,					// specify this as the last argument
 									// only tells the function that there are no more arguments
 	FP_CELL,						// normal cell
@@ -2074,9 +2087,12 @@ enum ForwardParam {
 	FP_STRING,						// string
 	FP_STRINGEX,					// string; will be updated to the last function's value
 	FP_ARRAY,						// array; use the return value of prepareArray.
+	FP_CELL_BYREF,                  // cell; pass by reference
+	FP_FLOAT_BYREF,                 // float; pass by reference
 };
 
-enum PlayerProp {
+enum PlayerProp
+{
 	Player_Name,		//String
 	Player_Ip,			//String
 	Player_Team,		//String
@@ -2098,7 +2114,8 @@ enum PlayerProp {
 	Player_NewmenuPage,		//int
 };
 
-enum LibType {
+enum LibType
+{
 	LibType_Library,
 	LibType_Class
 };
@@ -2109,54 +2126,58 @@ enum LibType {
 #define BLOCK_ONCE 1
 #define BLOCK_SET 2
 
-typedef void(*AUTHORIZEFUNC)(int player, const char *authstring);
+typedef void (*AUTHORIZEFUNC)(int player, const char *authstring);
 
-typedef int(*PFN_ADD_NATIVES)				(const AMX_NATIVE_INFO * /*list*/);
-typedef int(*PFN_ADD_NEW_NATIVES)			(const AMX_NATIVE_INFO * /*list*/);
+typedef int				(*PFN_ADD_NATIVES)				(const AMX_NATIVE_INFO * /*list*/);
+typedef int				(*PFN_ADD_NEW_NATIVES)			(const AMX_NATIVE_INFO * /*list*/);
 typedef char *			(*PFN_BUILD_PATHNAME)			(const char * /*format*/, ...);
 typedef char *			(*PFN_BUILD_PATHNAME_R)			(char * /*buffer*/, size_t /* maxlen */, const char * /* format */, ...);
 typedef cell *			(*PFN_GET_AMXADDR)				(AMX * /*amx*/, cell /*offset*/);
-typedef void(*PFN_PRINT_SRVCONSOLE)			(const char * /*format*/, ...);
+typedef cell *			(*PFN_GET_AMXVECTOR_NULL)		(AMX * /*amx*/, cell /*offset*/);
+typedef void			(*PFN_PRINT_SRVCONSOLE)			(const char * /*format*/, ...);
 typedef const char *	(*PFN_GET_MODNAME)				(void);
 typedef const char *	(*PFN_GET_AMXSCRIPTNAME)		(int /*id*/);
 typedef AMX *			(*PFN_GET_AMXSCRIPT)			(int /*id*/);
-typedef int(*PFN_FIND_AMXSCRIPT_BYAMX)		(const AMX * /*amx*/);
-typedef int(*PFN_FIND_AMXSCRIPT_BYNAME)	(const char * /*name*/);
-typedef int(*PFN_SET_AMXSTRING)			(AMX * /*amx*/, cell /*amx_addr*/, const char * /* source */, int /* max */);
+typedef int				(*PFN_FIND_AMXSCRIPT_BYAMX)		(const AMX * /*amx*/);
+typedef int				(*PFN_FIND_AMXSCRIPT_BYNAME)	(const char * /*name*/);
+typedef int				(*PFN_SET_AMXSTRING)			(AMX * /*amx*/, cell /*amx_addr*/, const char * /* source */, int /* max */);
+typedef int				(*PFN_SET_AMXSTRING_UTF8_CHAR)	(AMX *amx, cell amx_addr, const char *source, size_t sourcelen, size_t maxlen);
+typedef int				(*PFN_SET_AMXSTRING_UTF8_CELL)	(AMX *amx, cell amx_addr, const cell *source, size_t sourcelen, size_t maxlen);
 typedef char *			(*PFN_GET_AMXSTRING)			(AMX * /*amx*/, cell /*amx_addr*/, int /*bufferId*/, int * /*pLen*/);
-typedef int(*PFN_GET_AMXSTRINGLEN)			(const cell *ptr);
+typedef char *			(*PFN_GET_AMXSTRING_NULL)		(AMX * /*amx*/, cell /*amx_addr*/, int /*bufferId*/, int * /*pLen*/);
+typedef int				(*PFN_GET_AMXSTRINGLEN)			(const cell *ptr);
 typedef char *			(*PFN_FORMAT_AMXSTRING)			(AMX * /*amx*/, cell * /*params*/, int /*startParam*/, int * /*pLen*/);
-typedef void(*PFN_COPY_AMXMEMORY)			(cell * /*dest*/, const cell * /*src*/, int /*len*/);
-typedef void(*PFN_LOG)						(const char * /*fmt*/, ...);
-typedef void(*PFN_LOG_ERROR)				(AMX * /*amx*/, int /*err*/, const char * /*fmt*/, ...);
-typedef int(*PFN_RAISE_AMXERROR)			(AMX * /*amx*/, int /*error*/);
-typedef int(*PFN_REGISTER_FORWARD)			(const char * /*funcname*/, ForwardExecType /*exectype*/, ... /*paramtypes terminated by PF_DONE*/);
-typedef int(*PFN_EXECUTE_FORWARD)			(int /*id*/, ... /*params*/);
-typedef cell(*PFN_PREPARE_CELLARRAY)		(cell * /*ptr*/, unsigned int /*size*/);
-typedef cell(*PFN_PREPARE_CHARARRAY)		(char * /*ptr*/, unsigned int /*size*/);
-typedef cell(*PFN_PREPARE_CELLARRAY_A)		(cell * /*ptr*/, unsigned int /*size*/, bool /*copyBack*/);
-typedef cell(*PFN_PREPARE_CHARARRAY_A)		(char * /*ptr*/, unsigned int /*size*/, bool /*copyBack*/);
-typedef int(*PFN_IS_PLAYER_VALID)			(int /*id*/);
+typedef void			(*PFN_COPY_AMXMEMORY)			(cell * /*dest*/, const cell * /*src*/, int /*len*/);
+typedef void			(*PFN_LOG)						(const char * /*fmt*/, ...);
+typedef void			(*PFN_LOG_ERROR)				(AMX * /*amx*/, int /*err*/, const char * /*fmt*/, ...);
+typedef int				(*PFN_RAISE_AMXERROR)			(AMX * /*amx*/, int /*error*/);
+typedef int				(*PFN_REGISTER_FORWARD)			(const char * /*funcname*/, ForwardExecType /*exectype*/, ... /*paramtypes terminated by PF_DONE*/);
+typedef int				(*PFN_EXECUTE_FORWARD)			(int /*id*/, ... /*params*/);
+typedef cell			(*PFN_PREPARE_CELLARRAY)		(cell * /*ptr*/, unsigned int /*size*/);
+typedef cell			(*PFN_PREPARE_CHARARRAY)		(char * /*ptr*/, unsigned int /*size*/);
+typedef cell			(*PFN_PREPARE_CELLARRAY_A)		(cell * /*ptr*/, unsigned int /*size*/, bool /*copyBack*/);
+typedef cell			(*PFN_PREPARE_CHARARRAY_A)		(char * /*ptr*/, unsigned int /*size*/, bool /*copyBack*/);
+typedef int				(*PFN_IS_PLAYER_VALID)			(int /*id*/);
 typedef const char *	(*PFN_GET_PLAYER_NAME)			(int /*id*/);
 typedef const char *	(*PFN_GET_PLAYER_IP)			(int /*id*/);
-typedef int(*PFN_IS_PLAYER_INGAME)			(int /*id*/);
-typedef int(*PFN_IS_PLAYER_BOT)			(int /*id*/);
-typedef int(*PFN_IS_PLAYER_AUTHORIZED)		(int /*id*/);
-typedef float(*PFN_GET_PLAYER_TIME)			(int /*id*/);
-typedef float(*PFN_GET_PLAYER_PLAYTIME)		(int /*id*/);
-typedef int(*PFN_GETPLAYERFLAGS) 			(int /* id*/);
-typedef int(*PFN_GET_PLAYER_CURWEAPON)		(int /*id*/);
+typedef int				(*PFN_IS_PLAYER_INGAME)			(int /*id*/);
+typedef int				(*PFN_IS_PLAYER_BOT)			(int /*id*/);
+typedef int				(*PFN_IS_PLAYER_AUTHORIZED)		(int /*id*/);
+typedef float			(*PFN_GET_PLAYER_TIME)			(int /*id*/);
+typedef float			(*PFN_GET_PLAYER_PLAYTIME)		(int /*id*/);
+typedef int				(*PFN_GETPLAYERFLAGS) 			(int /* id*/);
+typedef int				(*PFN_GET_PLAYER_CURWEAPON)		(int /*id*/);
 typedef const char *    (*PFN_GET_PLAYER_TEAM)			(int /*id*/);
-typedef int(*PFN_GET_PLAYER_TEAMID)		(int /*id*/);
-typedef int(*PFN_GET_PLAYER_DEATHS)		(int /*id*/);
-typedef int(*PFN_GET_PLAYER_MENU)			(int /*id*/);
-typedef int(*PFN_GET_PLAYER_KEYS)			(int /*id*/);
-typedef int(*PFN_IS_PLAYER_ALIVE)			(int /*id*/);
-typedef int(*PFN_GET_PLAYER_FRAGS)			(int /*id*/);
-typedef int(*PFN_IS_PLAYER_CONNECTING)		(int /*id*/);
-typedef int(*PFN_IS_PLAYER_HLTV)			(int /*id*/);
-typedef int(*PFN_GET_PLAYER_ARMOR)			(int /*id*/);
-typedef int(*PFN_GET_PLAYER_HEALTH)		(int /*id*/);
+typedef int				(*PFN_GET_PLAYER_TEAMID)		(int /*id*/);
+typedef int				(*PFN_GET_PLAYER_DEATHS)		(int /*id*/);
+typedef int				(*PFN_GET_PLAYER_MENU)			(int /*id*/);
+typedef int				(*PFN_GET_PLAYER_KEYS)			(int /*id*/);
+typedef int				(*PFN_IS_PLAYER_ALIVE)			(int /*id*/);
+typedef int				(*PFN_GET_PLAYER_FRAGS)			(int /*id*/);
+typedef int				(*PFN_IS_PLAYER_CONNECTING)		(int /*id*/);
+typedef int				(*PFN_IS_PLAYER_HLTV)			(int /*id*/);
+typedef int				(*PFN_GET_PLAYER_ARMOR)			(int /*id*/);
+typedef int				(*PFN_GET_PLAYER_HEALTH)		(int /*id*/);
 #ifdef USE_METAMOD
 typedef edict_t *		(*PFN_GET_PLAYER_EDICT)			(int /*id*/);
 #else
@@ -2166,45 +2187,48 @@ typedef void *			(*PFN_PLAYER_PROP_ADDR)			(int /*id*/, int /*prop*/);
 
 #ifdef MEMORY_TEST
 typedef void *			(*PFN_ALLOCATOR)				(const char* /*filename*/, const unsigned int /*line*/, const char* /*func*/,
-	const unsigned int /*type*/, const size_t /*size*/);
+														 const unsigned int /*type*/, const size_t /*size*/);
 typedef void *			(*PFN_REALLOCATOR)				(const char* /*filename*/, const unsigned int /*line*/, const char* /*func*/,
-	const unsigned int /*type*/, const size_t /*size*/, void* /*addr*/);
-typedef void(*PFN_DEALLOCATOR)				(const char* /*filename*/, const unsigned int /*line*/, const char* /*func*/,
-	const unsigned int /*type*/, const void* /*addr*/);
+														 const unsigned int /*type*/, const size_t /*size*/, void* /*addr*/ );
+typedef void			(*PFN_DEALLOCATOR)				(const char* /*filename*/, const unsigned int /*line*/, const char* /*func*/,
+														 const unsigned int /*type*/, const void* /*addr*/ );
 #endif
-typedef int(*PFN_AMX_EXEC)					(AMX* /*amx*/, cell* /*return val*/, int /*index*/);
-typedef int(*PFN_AMX_EXECV)				(AMX* /*amx*/, cell* /*return val*/, int /*index*/, int /*numparams*/, cell[] /*params*/);
-typedef int(*PFN_AMX_ALLOT)				(AMX* /*amx*/, int /*length*/, cell* /*amx_addr*/, cell** /*phys_addr*/);
-typedef int(*PFN_AMX_FINDPUBLIC)			(AMX* /*amx*/, const char* /*func name*/, int* /*index*/);
-typedef int(*PFN_AMX_FINDNATIVE)			(AMX* /*amx*/, const char* /*func name*/, int* /*index*/);
-typedef int(*PFN_LOAD_AMXSCRIPT)			(AMX* /*amx*/, void** /*code*/, const char* /*path*/, char[64] /*error info*/, int /* debug */);
-typedef int(*PFN_UNLOAD_AMXSCRIPT)			(AMX* /*amx*/, void** /*code*/);
-typedef cell(*PFN_REAL_TO_CELL)				(REAL /*x*/);
-typedef REAL(*PFN_CELL_TO_REAL)				(cell /*x*/);
-typedef int(*PFN_REGISTER_SPFORWARD)		(AMX * /*amx*/, int /*func*/, ... /*params*/);
-typedef int(*PFN_REGISTER_SPFORWARD_BYNAME)	(AMX * /*amx*/, const char * /*funcName*/, ... /*params*/);
-typedef void(*PFN_UNREGISTER_SPFORWARD)		(int /*id*/);
-typedef	void(*PFN_MERGEDEFINITION_FILE)		(const char * /*filename*/);
+typedef int				(*PFN_AMX_EXEC)					(AMX* /*amx*/, cell* /*return val*/, int /*index*/);
+typedef int				(*PFN_AMX_EXECV)				(AMX* /*amx*/, cell* /*return val*/, int /*index*/, int /*numparams*/, cell[] /*params*/);
+typedef int				(*PFN_AMX_ALLOT)				(AMX* /*amx*/, int /*length*/, cell* /*amx_addr*/, cell** /*phys_addr*/);
+typedef int				(*PFN_AMX_FINDPUBLIC)			(AMX* /*amx*/, const char* /*func name*/, int* /*index*/);
+typedef int				(*PFN_AMX_FINDNATIVE)			(AMX* /*amx*/, const char* /*func name*/, int* /*index*/);
+typedef int				(*PFN_LOAD_AMXSCRIPT)			(AMX* /*amx*/, void** /*code*/, const char* /*path*/, char[64] /*error info*/, int /* debug */);
+typedef int				(*PFN_LOAD_AMXSCRIPT_EX)		(AMX* /*amx*/, void** /*code*/, const char* /*path*/, char* /*error info*/, size_t /* max length */, int /* debug */);
+typedef int				(*PFN_UNLOAD_AMXSCRIPT)			(AMX* /*amx*/,void** /*code*/);
+typedef cell			(*PFN_REAL_TO_CELL)				(REAL /*x*/);
+typedef REAL			(*PFN_CELL_TO_REAL)				(cell /*x*/);
+typedef int				(*PFN_REGISTER_SPFORWARD)		(AMX * /*amx*/, int /*func*/, ... /*params*/);
+typedef int				(*PFN_REGISTER_SPFORWARD_BYNAME)	(AMX * /*amx*/, const char * /*funcName*/, ... /*params*/);
+typedef void			(*PFN_UNREGISTER_SPFORWARD)		(int /*id*/);
+typedef	void			(*PFN_MERGEDEFINITION_FILE)		(const char * /*filename*/);
 typedef const char *	(*PFN_FORMAT)					(const char * /*fmt*/, ... /*params*/);
-typedef void(*PFN_REGISTERFUNCTION)			(void * /*pfn*/, const char * /*desc*/);
-typedef	int(*PFN_AMX_PUSH)					(AMX * /*amx*/, cell /*value*/);
-typedef	int(*PFN_SET_TEAM_INFO)			(int /*player */, int /*teamid */, const char * /*name */);
-typedef void(*PFN_REG_AUTH_FUNC)			(AUTHORIZEFUNC);
-typedef void(*PFN_UNREG_AUTH_FUNC)			(AUTHORIZEFUNC);
-typedef int(*PFN_FINDLIBRARY)				(const char * /*name*/, LibType /*type*/);
-typedef size_t(*PFN_ADDLIBRARIES)				(const char * /*name*/, LibType /*type*/, void * /*parent*/);
-typedef size_t(*PFN_REMOVELIBRARIES)			(void * /*parent*/);
-typedef void(*PFN_OVERRIDENATIVES)			(AMX_NATIVE_INFO * /*natives*/, const char * /*myname*/);
+typedef void			(*PFN_REGISTERFUNCTION)			(void * /*pfn*/, const char * /*desc*/);
+typedef	int				(*PFN_AMX_PUSH)					(AMX * /*amx*/, cell /*value*/);
+typedef	int				(*PFN_SET_TEAM_INFO)			(int /*player */, int /*teamid */, const char * /*name */);
+typedef void			(*PFN_REG_AUTH_FUNC)			(AUTHORIZEFUNC);
+typedef void			(*PFN_UNREG_AUTH_FUNC)			(AUTHORIZEFUNC);
+typedef int				(*PFN_FINDLIBRARY)				(const char * /*name*/, LibType /*type*/);
+typedef size_t			(*PFN_ADDLIBRARIES)				(const char * /*name*/, LibType /*type*/, void * /*parent*/);
+typedef size_t			(*PFN_REMOVELIBRARIES)			(void * /*parent*/);
+typedef void			(*PFN_OVERRIDENATIVES)			(AMX_NATIVE_INFO * /*natives*/, const char * /*myname*/);
 typedef const char *	(*PFN_GETLOCALINFO)				(const char * /*name*/, const char * /*def*/);
-typedef int(*PFN_AMX_REREGISTER)			(AMX * /*amx*/, AMX_NATIVE_INFO * /*list*/, int /*list*/);
+typedef int				(*PFN_AMX_REREGISTER)			(AMX * /*amx*/, AMX_NATIVE_INFO * /*list*/, int /*list*/);
 typedef void *			(*PFN_REGISTERFUNCTIONEX)		(void * /*pfn*/, const char * /*desc*/);
-typedef void(*PFN_MESSAGE_BLOCK)			(int /* mode */, int /* message */, int * /* opt */);
+typedef void			(*PFN_MESSAGE_BLOCK)			(int /* mode */, int /* message */, int * /* opt */);
+typedef IGameConfigManager* (*PFN_GET_CONFIG_MANAGER)   ();
 
 extern PFN_ADD_NATIVES				g_fn_AddNatives;
 extern PFN_ADD_NEW_NATIVES			g_fn_AddNewNatives;
 extern PFN_BUILD_PATHNAME			g_fn_BuildPathname;
 extern PFN_BUILD_PATHNAME_R			g_fn_BuildPathnameR;
 extern PFN_GET_AMXADDR				g_fn_GetAmxAddr;
+extern PFN_GET_AMXVECTOR_NULL		g_fn_GetAmxVectorNull;
 extern PFN_PRINT_SRVCONSOLE			g_fn_PrintSrvConsole;
 extern PFN_GET_MODNAME				g_fn_GetModname;
 extern PFN_GET_AMXSCRIPTNAME		g_fn_GetAmxScriptName;
@@ -2212,7 +2236,10 @@ extern PFN_GET_AMXSCRIPT			g_fn_GetAmxScript;
 extern PFN_FIND_AMXSCRIPT_BYAMX		g_fn_FindAmxScriptByAmx;
 extern PFN_FIND_AMXSCRIPT_BYNAME	g_fn_FindAmxScriptByName;
 extern PFN_SET_AMXSTRING			g_fn_SetAmxString;
+extern PFN_SET_AMXSTRING_UTF8_CHAR	g_fn_SetAmxStringUTF8Char;
+extern PFN_SET_AMXSTRING_UTF8_CELL	g_fn_SetAmxStringUTF8Cell;
 extern PFN_GET_AMXSTRING			g_fn_GetAmxString;
+extern PFN_GET_AMXSTRING_NULL		g_fn_GetAmxStringNull;
 extern PFN_GET_AMXSTRINGLEN			g_fn_GetAmxStringLen;
 extern PFN_FORMAT_AMXSTRING			g_fn_FormatAmxString;
 extern PFN_COPY_AMXMEMORY			g_fn_CopyAmxMemory;
@@ -2248,6 +2275,7 @@ extern PFN_AMX_EXEC					g_fn_AmxExec;
 extern PFN_AMX_ALLOT				g_fn_AmxAllot;
 extern PFN_AMX_FINDPUBLIC			g_fn_AmxFindPublic;
 extern PFN_LOAD_AMXSCRIPT			g_fn_LoadAmxScript;
+extern PFN_LOAD_AMXSCRIPT_EX		g_fn_LoadAmxScriptEx;
 extern PFN_UNLOAD_AMXSCRIPT			g_fn_UnloadAmxScript;
 extern PFN_REAL_TO_CELL				g_fn_RealToCell;
 extern PFN_CELL_TO_REAL				g_fn_CellToReal;
@@ -2275,79 +2303,85 @@ extern PFN_GETLOCALINFO				g_fn_GetLocalInfo;
 extern PFN_AMX_REREGISTER			g_fn_AmxReRegister;
 extern PFN_REGISTERFUNCTIONEX		g_fn_RegisterFunctionEx;
 extern PFN_MESSAGE_BLOCK			g_fn_MessageBlock;
+extern PFN_GET_CONFIG_MANAGER		g_fn_GetConfigManager;
 
 #ifdef MAY_NEVER_BE_DEFINED
 // Function prototypes for intellisense and similar systems
 // They understand #if 0 so we use #ifdef MAY_NEVER_BE_DEFINED
-int				MF_AddNatives(const AMX_NATIVE_INFO *list) {}
-int				MF_AddNewNatives(const AMX_NATIVE_INFO *list) {}
-char *			MF_BuildPathname(const char * format, ...) {}
-char *			MF_BuildPathnameR(char *buffer, size_t maxlen, const char *fmt, ...) {}
-cell *			MF_GetAmxAddr(AMX * amx, cell offset) {}
-void			MF_PrintSrvConsole(char * format, ...) {}
-const char *	MF_GetModname(void) {}
-const char *	MF_GetScriptName(int id) {}
-AMX *			MF_GetScriptAmx(int id) {}
-int				MF_FindScriptByAmx(const AMX * amx) {}
-int				MF_FindScriptByAmx(const char * name) {}
-int				MF_SetAmxString(AMX * amx, cell amx_addr, const char *  source, int  max) {}
-char *			MF_GetAmxString(AMX * amx, cell amx_addr, int bufferId, int * pLen) {}
-int				MF_GetAmxStringLen(const cell *ptr) {}
-char *			MF_FormatAmxString(AMX * amx, cell * params, int startParam, int * pLen) {}
-void			MF_CopyAmxMemory(cell * dest, const cell * src, int len) {}
-void			MF_Log(const char * fmt, ...) {}
-void			MF_LogError(AMX * amx, int err, const char *fmt, ...) {}
-int				MF_RaiseAmxError(AMX * amx, int error) {}
-int				MF_RegisterForward(const char * funcname, ForwardExecType exectype, ...) {}
-int				MF_ExecuteForward(int id, ...) {}
-cell			MF_PrepareCellArray(cell * ptr, unsigned int size) {}
-cell			MF_PrepareCharArray(char * ptr, unsigned int size) {}
-cell			MF_PrepareCellArrayA(cell * ptr, unsigned int size, bool copyBack) {}
-cell			MF_PrepareCharArrayA(char * ptr, unsigned int size, bool copyBack) {}
-int				MF_IsPlayerValid(int id) {}
-const char *	MF_GetPlayerName(int id) {}
-const char *	MF_GetPlayerIP(int id) {}
-int				MF_IsPlayerIngame(int id) {}
-int				MF_IsPlayerBot(int id) {}
-int				MF_IsPlayerAuthorized(int id) {}
-float			MF_GetPlayerTime(int id) {}
-float			MF_GetPlayerPlayTime(int id) {}
-int				MF_GetPlayerCurweapon(int id) {}
-const char *	MF_GetPlayerTeam(int id) {}
-int				MF_GetPlayerTeamID(int id) {}
-int				MF_GetPlayerDeaths(int id) {}
-int				MF_GetPlayerMenu(int id) {}
-int				MF_GetPlayerKeys(int id) {}
-int				MF_IsPlayerAlive(int id) {}
-int				MF_GetPlayerFrags(int id) {}
-int				MF_IsPlayerConnecting(int id) {}
-int				MF_IsPlayerHLTV(int id) {}
-int				MF_GetPlayerArmor(int id) {}
-int				MF_GetPlayerHealth(int id) {}
-REAL			amx_ctof(cell x) {}
-cell			amx_ftoc(float x) {}
-int				MF_RegisterSPForwardByName(AMX * amx, const char *str, ...) {}
-int				MF_RegisterSPForward(AMX * amx, int func, ...) {}
-void			MF_UnregisterSPForward(int id) {}
-int				MF_GetPlayerFlags(int id) {}
-edict_t*		MF_GetPlayerEdict(int id) {}
-const char *	MF_Format(const char *fmt, ...) {}
-void			MF_RegisterFunction(void *pfn, const char *description) {}
-void *			MF_RequestFunction(const char *description) {}
-int				MF_AmxPush(AMX *amx, cell *params) {}
-int				MF_AmxExec(AMX *amx, cell *retval, int idx) {}
-int				MF_SetPlayerTeamInfo(int id, int teamid, const char *teamname) {}
-void *			MF_PlayerPropAddr(int id, int prop) {}
-void			MF_RegAuthFunc(AUTHORIZEFUNC fn) {}
-void			MF_UnregAuthFunc(AUTHORIZEFUNC fn) {}
-int				MF_FindLibrary(const char *name, LibType type) {}
-size_t			MF_AddLibraries(const char *name, LibType type, void *parent) {}
-size_t			MF_RemoveLibraries(void *parent) {}
-void			MF_OverrideNatives(AMX_NATIVE_INFO *natives, const char *myname) {}
-const char *	MF_GetLocalInfo(const char *name, const char *def) {}
-int				MF_AmxReRegister(AMX *amx, AMX_NATIVE_INFO *list, int number) { return 0; }
-void *			MF_RegisterFunctionEx(void *pfn, const char *description) {}
-void *			MF_MessageBlock(int mode, int msg, int *opt) {}
+int				MF_AddNatives				(const AMX_NATIVE_INFO *list) { }
+int				MF_AddNewNatives			(const AMX_NATIVE_INFO *list) { }
+char *			MF_BuildPathname			(const char * format, ...) { }
+char *			MF_BuildPathnameR			(char *buffer, size_t maxlen, const char *fmt, ...) { }
+cell *			MF_GetAmxAddr				(AMX * amx, cell offset) { }
+cell *			MF_GetAmxVectorNull			(AMX * amx, cell offset) { }
+void			MF_PrintSrvConsole			(char * format, ...) { }
+const char *	MF_GetModname				(void) { }
+const char *	MF_GetScriptName			(int id) { }
+AMX *			MF_GetScriptAmx				(int id) { }
+int				MF_FindScriptByAmx			(const AMX * amx) { }
+int				MF_FindScriptByAmx			(const char * name) { }
+int				MF_SetAmxString				(AMX * amx, cell amx_addr, const char *  source , int  max ) { }
+int				MF_SetAmxStringUTF8Char		(AMX *amx, cell amx_addr, const char *source, size_t sourcelen, size_t maxlen) { }
+int				MF_SetAmxStringUTF8Cell		(AMX *amx, cell amx_addr, const cell *source, size_t sourcelen, size_t maxlen) { }
+char *			MF_GetAmxString				(AMX * amx, cell amx_addr, int bufferId, int * pLen) { }
+char *			MF_GetAmxStringNull			(AMX * amx, cell amx_addr, int bufferId, int * pLen) { }
+int				MF_GetAmxStringLen			(const cell *ptr) { }
+char *			MF_FormatAmxString			(AMX * amx, cell * params, int startParam, int * pLen) { }
+void			MF_CopyAmxMemory			(cell * dest, const cell * src, int len) { }
+void			MF_Log						(const char * fmt, ...) { }
+void			MF_LogError					(AMX * amx, int err, const char *fmt, ...) { }
+int				MF_RaiseAmxError			(AMX * amx, int error) { }
+int				MF_RegisterForward			(const char * funcname, ForwardExecType exectype, ...) { }
+int				MF_ExecuteForward			(int id, ...) { }
+cell			MF_PrepareCellArray			(cell * ptr, unsigned int size) { }
+cell			MF_PrepareCharArray			(char * ptr, unsigned int size) { }
+cell			MF_PrepareCellArrayA			(cell * ptr, unsigned int size, bool copyBack) { }
+cell			MF_PrepareCharArrayA			(char * ptr, unsigned int size, bool copyBack) { }
+int				MF_IsPlayerValid			(int id) { }
+const char *	MF_GetPlayerName			(int id) { }
+const char *	MF_GetPlayerIP				(int id) { }
+int				MF_IsPlayerIngame			(int id) { }
+int				MF_IsPlayerBot				(int id) { }
+int				MF_IsPlayerAuthorized		(int id) { }
+float			MF_GetPlayerTime			(int id) { }
+float			MF_GetPlayerPlayTime		(int id) { }
+int				MF_GetPlayerCurweapon		(int id) { }
+const char *	MF_GetPlayerTeam			(int id) { }
+int				MF_GetPlayerTeamID			(int id) { }
+int				MF_GetPlayerDeaths			(int id) { }
+int				MF_GetPlayerMenu			(int id) { }
+int				MF_GetPlayerKeys			(int id) { }
+int				MF_IsPlayerAlive			(int id) { }
+int				MF_GetPlayerFrags			(int id) { }
+int				MF_IsPlayerConnecting		(int id) { }
+int				MF_IsPlayerHLTV				(int id) { }
+int				MF_GetPlayerArmor			(int id) { }
+int				MF_GetPlayerHealth			(int id) { }
+REAL			amx_ctof					(cell x) { }
+cell			amx_ftoc					(float x) { }
+int				MF_RegisterSPForwardByName	(AMX * amx, const char *str, ...) { }
+int				MF_RegisterSPForward		(AMX * amx, int func, ...) { }
+void			MF_UnregisterSPForward		(int id) { }
+int				MF_GetPlayerFlags			(int id) { }
+edict_t*		MF_GetPlayerEdict			(int id) { }
+const char *	MF_Format					(const char *fmt, ...) { }
+void			MF_RegisterFunction			(void *pfn, const char *description) { }
+void *			MF_RequestFunction			(const char *description) { }
+int				MF_AmxPush					(AMX *amx, cell *params) { }
+int				MF_AmxExec					(AMX *amx, cell *retval, int idx) { }
+int				MF_SetPlayerTeamInfo		(int id, int teamid, const char *teamname) { }
+void *			MF_PlayerPropAddr			(int id, int prop) { }
+void			MF_RegAuthFunc				(AUTHORIZEFUNC fn) { }
+void			MF_UnregAuthFunc			(AUTHORIZEFUNC fn) { }
+int				MF_FindLibrary				(const char *name, LibType type) { }
+size_t			MF_AddLibraries				(const char *name, LibType type, void *parent) { }
+size_t			MF_RemoveLibraries			(void *parent) { }
+void			MF_OverrideNatives			(AMX_NATIVE_INFO *natives, const char *myname) { }
+const char *	MF_GetLocalInfo				(const char *name, const char *def) { }
+int				MF_AmxReRegister			(AMX *amx, AMX_NATIVE_INFO *list, int number) { return 0; }
+void *			MF_RegisterFunctionEx		(void *pfn, const char *description) { }
+void *			MF_MessageBlock				(int mode, int msg, int *opt) { }
+IGameConfigManager* MF_GetConfigManager     (void) { }
 #endif	// MAY_NEVER_BE_DEFINED
 
 #define MF_AddNatives g_fn_AddNatives
@@ -2356,6 +2390,7 @@ void *			MF_MessageBlock(int mode, int msg, int *opt) {}
 #define MF_BuildPathnameR g_fn_BuildPathnameR
 #define MF_FormatAmxString g_fn_FormatAmxString
 #define MF_GetAmxAddr g_fn_GetAmxAddr
+#define MF_GetAmxVectorNull g_fn_GetAmxVectorNull
 #define MF_PrintSrvConsole g_fn_PrintSrvConsole
 #define MF_GetModname g_fn_GetModname
 #define MF_GetScriptName g_fn_GetAmxScriptName
@@ -2363,7 +2398,10 @@ void *			MF_MessageBlock(int mode, int msg, int *opt) {}
 #define MF_FindScriptByAmx g_fn_FindAmxScriptByAmx
 #define MF_FindScriptByName g_fn_FindAmxScriptByName
 #define MF_SetAmxString g_fn_SetAmxString
+#define MF_SetAmxStringUTF8Char g_fn_SetAmxStringUTF8Char
+#define MF_SetAmxStringUTF8Cell g_fn_SetAmxStringUTF8Cell
 #define MF_GetAmxString g_fn_GetAmxString
+#define MF_GetAmxStringNull g_fn_GetAmxStringNull
 #define MF_GetAmxStringLen g_fn_GetAmxStringLen
 #define MF_CopyAmxMemory g_fn_CopyAmxMemory
 void MF_Log(const char *fmt, ...);
@@ -2401,6 +2439,7 @@ void MF_LogError(AMX *amx, int err, const char *fmt, ...);
 #define MF_AmxAllot g_fn_AmxAllot
 #define MF_AmxFindNative g_fn_AmxFindNative
 #define MF_LoadAmxScript g_fn_LoadAmxScript
+#define MF_LoadAmxScriptEx g_fn_LoadAmxScriptEx
 #define MF_UnloadAmxScript g_fn_UnloadAmxScript
 #define MF_MergeDefinitionFile g_fn_MergeDefinition_File
 #define amx_ctof g_fn_CellToReal
@@ -2426,6 +2465,7 @@ void MF_LogError(AMX *amx, int err, const char *fmt, ...);
 #define MF_AmxReRegister g_fn_AmxReRegister
 #define MF_RegisterFunctionEx g_fn_RegisterFunctionEx
 #define MF_MessageBlock g_fn_MessageBlock
+#define MF_GetConfigManager g_fn_GetConfigManager
 
 #ifdef MEMORY_TEST
 /*** Memory ***/
@@ -2451,11 +2491,11 @@ extern	const	unsigned int	m_alloc_free;
 void	Mem_SetOwner(const char *filename, int line, const char *function);
 // Actual allocator
 void *	Mem_Allocator(const char *sourceFile, const unsigned int sourceLine, const char *sourceFunc,
-	const unsigned int allocationType, const size_t reportedSize);
+					const unsigned int allocationType, const size_t reportedSize);
 void *	Mem_Reallocator(const char *sourceFile, const unsigned int sourceLine, const char *sourceFunc,
-	const unsigned int reallocationType, const size_t reportedSize, void *reportedAddress);
+					const unsigned int reallocationType, const size_t reportedSize, void *reportedAddress);
 void	Mem_Deallocator(const char *sourceFile, const unsigned int sourceLine, const char *sourceFunc,
-	const unsigned int deallocationType, void *reportedAddress);
+					const unsigned int deallocationType, void *reportedAddress);
 
 // memory macros
 #ifndef __FUNCTION__
@@ -2472,5 +2512,7 @@ void	Mem_Deallocator(const char *sourceFile, const unsigned int sourceLine, cons
 #define	free(ptr)	Mem_Deallocator(__FILE__,__LINE__,__FUNCTION__,m_alloc_free,ptr)
 
 #endif //MEMORY_TEST
+
+template <typename D, typename S> unsigned int strncopy(D *dest, const S *src, size_t count);
 
 #endif // #ifndef __AMXXMODULE_H__

--- a/public/amxxsdk/moduleconfig.h
+++ b/public/amxxsdk/moduleconfig.h
@@ -1,25 +1,36 @@
-// Configuration
+// vim: set ts=4 sw=4 tw=99 noet:
+//
+// AMX Mod X, based on AMX Mod by Aleksander Naszko ("OLO").
+// Copyright (C) The AMX Mod X Development Team.
+//
+// This software is licensed under the GNU General Public License, version 3 or higher.
+// Additional exceptions apply. For full license details, see LICENSE.txt or visit:
+//     https://alliedmods.net/amxmodx-license
+
+//
+// Module Config
+//
 
 #ifndef __MODULECONFIG_H__
 #define __MODULECONFIG_H__
 
 /** Module info
-* -The logtag is the tag that the module's log messages will be
-*   prepended with.
-* -The library is the name that the #pragma library
-*   message will have prepended.
-* -The library class is the class of libraries that
-*   a module belongs to (like DBI).  Keep it "" to
-*   ignore.
-* -For both library and library class, you can use a comma
-*   to add multiple entries.
-*/
-#define MODULE_NAME "Custom Entity Data"
-#define MODULE_VERSION "1.0.2"
-#define MODULE_AUTHOR "KliPPy"
-#define MODULE_URL "http://"
-#define MODULE_LOGTAG "CED"
-#define MODULE_LIBRARY "customentdata"
+ * -The logtag is the tag that the module's log messages will be
+ *   prepended with.
+ * -The library is the name that the #pragma library
+ *   message will have prepended.
+ * -The library class is the class of libraries that 
+ *   a module belongs to (like DBI).  Keep it "" to 
+ *   ignore.
+ * -For both library and library class, you can use a comma
+ *   to add multiple entries.
+ */
+#define MODULE_NAME 	"Custom Entity Data"
+#define MODULE_VERSION 	"1.0.3"
+#define MODULE_AUTHOR 	"KliPPy"
+#define MODULE_URL 	"https://github.com/rsKliPPy/customentdata_amxx"
+#define MODULE_LOGTAG 	"CED"
+#define MODULE_LIBRARY 	"customentdata"
 #define MODULE_LIBCLASS ""
 // If you want the module not to be reloaded on mapchange, remove / comment out the next line
 #define MODULE_RELOAD_ON_MAPCHANGE
@@ -46,31 +57,31 @@
 // Uncomment this if you are using MSVC8 or greater and want to fix some of the compatibility issues yourself 
 // #define NO_MSVC8_AUTO_COMPAT
 
-/**
-* AMXX Init functions
-* Also consider using FN_META_*
-*/
+/** 
+ * AMXX Init functions
+ * Also consider using FN_META_*
+ */
 
 /** AMXX query */
 //#define FN_AMXX_QUERY OnAmxxQuery
 
 /** AMXX Check Game - module API is NOT available here.
-* Return AMXX_GAME_OK if this module can load on the game, AMXX_GAME_BAD if it cannot.
-* syntax: int AmxxCheckGame(const char *game)
-*/
+ * Return AMXX_GAME_OK if this module can load on the game, AMXX_GAME_BAD if it cannot.
+ * syntax: int AmxxCheckGame(const char *game)
+ */
 //#define FN_AMXX_CHECKGAME AmxxCheckGame
 
 /** AMXX attach
-* Do native functions init here (MF_AddNatives)
-*/
+ * Do native functions init here (MF_AddNatives)
+ */
 #define FN_AMXX_ATTACH OnAmxxAttach
 
 /** AMXX Detach (unload) */
 //#define FN_AMXX_DETACH OnAmxxDetach
 
 /** All plugins loaded
-* Do forward functions init here (MF_RegisterForward)
-*/
+ * Do forward functions init here (MF_RegisterForward)
+ */
 #define FN_AMXX_PLUGINSLOADED OnPluginsLoaded
 
 /** All plugins are about to be unloaded */

--- a/public/sm_stringhashmap.h
+++ b/public/sm_stringhashmap.h
@@ -44,11 +44,15 @@
  * NameHashSet instead.
  */
 
+#include <string.h>
+
+#include <utility>
+#undef max
+#undef min
+
 #include <amtl/am-allocator-policies.h>
 #include <amtl/am-hashmap.h>
 #include <amtl/am-string.h>
-#include <amtl/am-moveable.h>
-#include <string.h>
 
 //namespace SourceMod
 //{
@@ -73,7 +77,7 @@ namespace detail
 	  uint32_t hash() const {
 		  return hash_;
 	  }
-	  const char *chars() const {
+	  const char *c_str() const {
 		  return str_;
 	  }
 	  size_t length() const {
@@ -88,9 +92,9 @@ namespace detail
 
 	struct StringHashMapPolicy
 	{
-		static inline bool matches(const CharsAndLength &lookup, const ke::AString &key) {
+		static inline bool matches(const CharsAndLength &lookup, const std::string &key) {
 			return lookup.length() == key.length() &&
-				   memcmp(lookup.chars(), key.chars(), key.length()) == 0;
+				   memcmp(lookup.c_str(), key.c_str(), key.length()) == 0;
 		}
 		static inline uint32_t hash(const CharsAndLength &key) {
 			return key.hash();
@@ -102,7 +106,7 @@ template <typename T>
 class StringHashMap
 {
 	typedef detail::CharsAndLength CharsAndLength;
-	typedef ke::HashMap<ke::AString, T, detail::StringHashMapPolicy> Internal;
+	typedef ke::HashMap<std::string, T, detail::StringHashMapPolicy> Internal;
 
 public:
 	StringHashMap()
@@ -133,9 +137,8 @@ public:
 	{
 		CharsAndLength key(aKey);
 		Result r = internal_.find(key);
-		if(!r.found())
+		if (!r.found())
 			return false;
-			
 		*aResult = &r->value;
 		return true;
 	}
@@ -164,7 +167,7 @@ public:
 			if (!internal_.add(i, aKey))
 				return false;
 		}
-		i->value = ke::Forward<UV>(value);
+		i->value = std::forward<UV>(value);
 		return true;
 	}
 
@@ -175,7 +178,7 @@ public:
 		Insert i = internal_.findForAdd(key);
 		if (i.found())
 			return false;
-		if (!internal_.add(i, aKey, ke::Forward<UV>(value)))
+		if (!internal_.add(i, aKey, std::forward<UV>(value)))
 			return false;
 		memory_used_ += key.length() + 1;
 		return true;

--- a/source/EntData.h
+++ b/source/EntData.h
@@ -3,7 +3,7 @@
 
 #include "amxxsdk/amxxmodule.h"
 #include <amtl/am-string.h>
-#include <amtl/am-autoptr.h>
+//#include <amtl/am-autoptr.h>
 
 class IEntDataEntry
 {
@@ -46,12 +46,12 @@ public:
         return EntryType::Array;
     }
 
-    EntDataArray(ke::AutoPtr<cell[]> &&data, size_t size) : Data(ke::Move(data)), DataSize(size)
+    EntDataArray(std::unique_ptr<cell[]> &&data, size_t size) : Data(std::move(data)), DataSize(size)
     {
     }
 
 public:
-    ke::AutoPtr<cell[]> Data;
+    std::unique_ptr<cell[]> Data;
     size_t DataSize;
 };
 
@@ -68,7 +68,7 @@ public:
     }
 
 public:
-    ke::AString Data;
+    std::string Data;
 };
 
 #endif // CENTDATAENTRY_H

--- a/source/amxx_api.cpp
+++ b/source/amxx_api.cpp
@@ -25,4 +25,6 @@ void OnFreeEntPrivateData_Post(edict_t *ed)
     // TODO: Let plugins somehow release handles bound to this entity
 
     g_entityData[g_engfuncs.pfnIndexOfEdict(ed)].clear();
+
+    RETURN_META(MRES_IGNORED);
 }

--- a/source/amxx_api.cpp
+++ b/source/amxx_api.cpp
@@ -1,6 +1,6 @@
 #include "module.h"
 
-StringHashMap<ke::AutoPtr<IEntDataEntry>> *g_entityData = nullptr;
+StringHashMap<std::unique_ptr<IEntDataEntry>> *g_entityData = nullptr;
 
 void OnAmxxAttach()
 {
@@ -9,7 +9,7 @@ void OnAmxxAttach()
 
 void OnPluginsLoaded()
 {
-    g_entityData = new StringHashMap<ke::AutoPtr<IEntDataEntry>>[gpGlobals->maxEntities];
+    g_entityData = new StringHashMap<std::unique_ptr<IEntDataEntry>>[gpGlobals->maxEntities];
 }
 
 void OnPluginsUnloaded()
@@ -18,8 +18,6 @@ void OnPluginsUnloaded()
     {
         g_entityData[i].clear();
     }
-
-    delete g_entityData;
 }
 
 void OnFreeEntPrivateData_Post(edict_t *ed)

--- a/source/module.h
+++ b/source/module.h
@@ -2,12 +2,11 @@
 #define MODULE_H
 
 #include "amxxsdk/amxxmodule.h"
-#include <amtl/am-autoptr.h>
 #include "sm_stringhashmap.h"
 #include "EntData.h"
 
 
 extern AMX_NATIVE_INFO g_natives[];
-extern StringHashMap<ke::AutoPtr<IEntDataEntry>> *g_entityData;
+extern StringHashMap<std::unique_ptr<IEntDataEntry>> *g_entityData;
 
 #endif // MODULE_H

--- a/source/natives.cpp
+++ b/source/natives.cpp
@@ -17,7 +17,7 @@ static cell Native_SetCell(AMX *amx, cell *params)
 {
     NATIVE_SETUP();
 
-    g_entityData[index].replace(key, ke::AutoPtr<IEntDataEntry>(new EntDataCell(params[3])));
+    g_entityData[index].replace(key, std::unique_ptr<IEntDataEntry>(new EntDataCell(params[3])));
 
     return 0;
 }
@@ -27,10 +27,10 @@ static cell Native_SetArray(AMX *amx, cell *params)
 {
     NATIVE_SETUP();
     
-    ke::AutoPtr<cell[]> data(new cell[params[4]]);
+    std::unique_ptr<cell[]> data(new cell[params[4]]);
     MF_CopyAmxMemory(data.get(), MF_GetAmxAddr(amx, params[3]), params[4]);
 
-    g_entityData[index].replace(key, ke::AutoPtr<IEntDataEntry>(new EntDataArray(ke::Move(data), params[4])));
+    g_entityData[index].replace(key, std::unique_ptr<IEntDataEntry>(new EntDataArray(std::move(data), params[4])));
 
     return 0;
 }
@@ -40,7 +40,7 @@ static cell Native_SetString(AMX *amx, cell *params)
 {
     NATIVE_SETUP();
 
-    g_entityData[index].replace(key, ke::AutoPtr<IEntDataEntry>(new EntDataString(MF_GetAmxString(amx, params[3], 2, &dummyLen))));
+    g_entityData[index].replace(key, std::unique_ptr<IEntDataEntry>(new EntDataString(MF_GetAmxString(amx, params[3], 2, &dummyLen))));
 
     return 0;
 }
@@ -50,7 +50,7 @@ static cell Native_GetCell(AMX *amx, cell *params)
 {
     NATIVE_SETUP();
 
-    ke::AutoPtr<IEntDataEntry> *ptrData;
+    std::unique_ptr<IEntDataEntry> *ptrData;
     if(g_entityData[index].retrieve(key, &ptrData))
     {
         EntDataCell *data = static_cast<EntDataCell *>(ptrData->get());
@@ -69,7 +69,7 @@ static cell Native_GetArray(AMX *amx, cell *params)
 {
     NATIVE_SETUP();
 
-    ke::AutoPtr<IEntDataEntry> *ptrData;
+    std::unique_ptr<IEntDataEntry> *ptrData;
     if(g_entityData[index].retrieve(key, &ptrData))
     {
         EntDataArray *data = static_cast<EntDataArray *>(ptrData->get());
@@ -93,14 +93,14 @@ static cell Native_GetString(AMX *amx, cell *params)
 {
     NATIVE_SETUP();
 
-    ke::AutoPtr<IEntDataEntry> *ptrData;
+    std::unique_ptr<IEntDataEntry> *ptrData;
     if(g_entityData[index].retrieve(key, &ptrData))
     {
         EntDataString *data = static_cast<EntDataString *>(ptrData->get());
         if(data->GetEntryType() != IEntDataEntry::EntryType::String)
             return 0;
 
-        MF_SetAmxString(amx, params[3], data->Data.chars(), params[4]);
+        MF_SetAmxString(amx, params[3], data->Data.c_str(), params[4]);
         return 1;
     }
     


### PR DESCRIPTION
change ke::AutoPtr to std::unique_ptr.
change ke::Move to std::move.
use latest version amxxmodule.cpp, .h, moduleconfig.h
use sourcemod version sm_stringhashmap.h
add IGameConfigs.h (maybe not use.)
add ITextParsers.h (maybe not use.)
remove ```delete g_entityData;``` (I removed it because it crashed with invalid pointer, but I am concerned about memory leaks.)
add compile option for c++14.
